### PR TITLE
Fix delete tool to respect multi-selection

### DIFF
--- a/frontend/src/editor/components/stage/stage.tsx
+++ b/frontend/src/editor/components/stage/stage.tsx
@@ -534,7 +534,13 @@ export const Stage = ({
         .reverse()
         .find((a) => actorFillsPoint(a, characters, { x, y }));
       if (actor) {
-        dispatch(deleteActors(selFor([actor.id])));
+        // If the clicked actor is part of the selection, delete all selected actors
+        const selectedIds = selected.map((a) => a.id);
+        if (selectedIds.includes(actor.id)) {
+          dispatch(deleteActors(selFor(selectedIds)));
+        } else {
+          dispatch(deleteActors(selFor([actor.id])));
+        }
       }
     }
   };


### PR DESCRIPTION
When using the trash/delete tool, if the clicked actor is part of the
current selection, all selected actors are now deleted (consistent with
the Delete key behavior). If the clicked actor is not in the selection,
only that actor is deleted.