### PR TITLE
Fix color palette to always be clickable

### DIFF
--- a/frontend/src/editor/components/modal-paint/container.jsx
+++ b/frontend/src/editor/components/modal-paint/container.jsx
@@ -723,9 +723,9 @@ class Container extends React.Component {
             <div className="flex-horizontal" style={{ gap: 8 }}>
               <div className="paint-sidebar">
                 <PixelColorPicker
-                  tool={tool}
                   color={color}
                   onColorChange={(c) => this.setState({ color: c })}
+                  supported={tool.supportsColor()}
                 />
                 <PixelToolbar tools={TOOLS} tool={tool} onToolChange={this._onChooseTool} />
                 <PixelToolSize

--- a/frontend/src/editor/components/modal-paint/pixel-color-picker.jsx
+++ b/frontend/src/editor/components/modal-paint/pixel-color-picker.jsx
@@ -41,15 +41,14 @@ export default class PixelColorPicker extends React.Component {
   static propTypes = {
     color: PropTypes.string,
     onColorChange: PropTypes.func,
+    supported: PropTypes.bool,
   };
 
   render() {
-    const { tool, color, onColorChange } = this.props;
-
-    const disabled = !tool.supportsColor();
+    const { color, onColorChange, supported } = this.props;
 
     return (
-      <div className={classNames("pixel-color-picker", disabled && "disabled")}>
+      <div className={classNames("pixel-color-picker", !supported && "disabled")}>
         {color === "rgba(0,0,0,0)" ? (
           <div
             className="active-swatch transparent"
@@ -63,8 +62,7 @@ export default class PixelColorPicker extends React.Component {
           <input
             className={"active-swatch"}
             type="color"
-            disabled={disabled}
-            value={disabled ? "#cccccc" : rgbaToHex(color)}
+            value={rgbaToHex(color)}
             onChange={(e) => {
               if (e.target.value) {
                 const newColor = hexToRgba(e.target.value);
@@ -80,8 +78,7 @@ export default class PixelColorPicker extends React.Component {
               background: option === "rgba(0,0,0,0)" ? TRANSPARENT_CROSS : option,
               backgroundSize: "contain",
             }}
-            disabled={disabled}
-            className={classNames({ color: true, selected: !disabled && color === option })}
+            className={classNames({ color: true, selected: color === option })}
             onClick={() => onColorChange(option)}
           />
         ))}


### PR DESCRIPTION
Previously the color palette was disabled when a non-drawing tool
(eraser, selection) was selected. Now users can select colors first
and then pick a tool. The palette still shows a disabled appearance
when the current tool doesn't use colors, via a new `supported` prop.