### PR TITLE
Support non-square canvas sizes for AI sprite generation

### DIFF
--- a/frontend/src/editor/components/modal-paint/container.jsx
+++ b/frontend/src/editor/components/modal-paint/container.jsx
@@ -467,9 +467,14 @@ class Container extends React.Component {
     const description = this.state.spriteDescription;
     const prompt = `Generate a pixel art sprite with a solid background based on the following description: ${description}`;
 
+    // Pass canvas dimensions so the API can request an appropriately-shaped image
+    const { imageData } = this.state;
+    const canvasWidth = imageData.width;
+    const canvasHeight = imageData.height;
+
     this.setState({ isGeneratingSprite: true });
     try {
-      const data = await makeRequest(`/generate-sprite?prompt=${encodeURIComponent(prompt)}`);
+      const data = await makeRequest(`/generate-sprite?prompt=${encodeURIComponent(prompt)}&width=${canvasWidth}&height=${canvasHeight}`);
       if (data.imageUrl) {
         console.log("data.imageUrl", data.imageUrl);
         this._onApplyExternalDataURL(data.imageUrl);

--- a/frontend/src/editor/components/modal-paint/container.jsx
+++ b/frontend/src/editor/components/modal-paint/container.jsx
@@ -376,13 +376,14 @@ class Container extends React.Component {
     }
   };
 
-  _onApplyExternalDataURL = (dataURL, offset) => {
+  _onApplyExternalDataURL = (dataURL, offset, { fill } = {}) => {
     const { imageData } = this.state;
     getImageDataFromDataURL(
       dataURL,
       {
         maxWidth: imageData.width,
         maxHeight: imageData.height,
+        fill,
       },
       (nextSelectionImageData) => {
         CreatePixelImageData.call(nextSelectionImageData);
@@ -477,7 +478,8 @@ class Container extends React.Component {
       const data = await makeRequest(`/generate-sprite?prompt=${encodeURIComponent(prompt)}&width=${canvasWidth}&height=${canvasHeight}`);
       if (data.imageUrl) {
         console.log("data.imageUrl", data.imageUrl);
-        this._onApplyExternalDataURL(data.imageUrl);
+        // Use fill:true to ensure the AI image fills the entire canvas
+        this._onApplyExternalDataURL(data.imageUrl, null, { fill: true });
       } else {
         console.error("Failed to generate sprite:", data.error);
       }


### PR DESCRIPTION
Pass canvas dimensions from frontend to generate-sprite API and select
appropriate DALL-E 3 image size based on aspect ratio:
- Portrait canvases (aspect < 0.77) use 1024x1792
- Landscape canvases (aspect > 1.3) use 1792x1024
- Square-ish canvases use 1024x1024

This fixes the issue where a 1x2 canvas would only get half-filled
because the AI was always generating square images.