### PR TITLE
Fix garbled drag image for rotated/flipped actors

### DIFF
--- a/frontend/src/editor/components/sprites/actor-sprite.tsx
+++ b/frontend/src/editor/components/sprites/actor-sprite.tsx
@@ -1,6 +1,6 @@
 import { Actor, Character } from "../../../types";
 import { STAGE_CELL_SIZE } from "../../constants/constants";
-import { pointApplyingTransform } from "../../utils/stage-helpers";
+import { applyActorTransformToContext, pointApplyingTransform } from "../../utils/stage-helpers";
 import VariableOverlay from "../modal-paint/variable-overlay";
 import { DEFAULT_APPEARANCE_INFO, SPRITE_TRANSFORM_CSS } from "./sprite";
 
@@ -80,12 +80,15 @@ const ActorSprite = (props: {
     }
 
     const { top, left } = event.target.getBoundingClientRect();
+    const dragLeft = event.clientX - left;
+    const dragTop = event.clientY - top;
+
     event.dataTransfer.effectAllowed = "copyMove";
     event.dataTransfer.setData(
       "drag-offset",
       JSON.stringify({
-        dragLeft: event.clientX - left,
-        dragTop: event.clientY - top,
+        dragLeft,
+        dragTop,
       }),
     );
     event.dataTransfer.setData(
@@ -95,6 +98,61 @@ const ActorSprite = (props: {
         actorIds: dragActorIds,
       }),
     );
+
+    // Create a properly transformed drag image using canvas
+    // This fixes garbled appearance when dragging rotated/flipped actors
+    const imgEl = event.target.tagName === "IMG"
+      ? (event.target as HTMLImageElement)
+      : event.target.querySelector("img");
+
+    if (imgEl) {
+      const transform = actor.transform ?? "0";
+      const imgWidth = imgEl.naturalWidth || imgEl.width;
+      const imgHeight = imgEl.naturalHeight || imgEl.height;
+
+      // For rotations by 90 or 270 degrees, the canvas dimensions need to be swapped
+      const needsSwap = transform === "90" || transform === "270" || transform === "d1" || transform === "d2";
+      const canvasWidth = needsSwap ? imgHeight : imgWidth;
+      const canvasHeight = needsSwap ? imgWidth : imgHeight;
+
+      const canvas = document.createElement("canvas");
+      canvas.width = canvasWidth;
+      canvas.height = canvasHeight;
+      const ctx = canvas.getContext("2d");
+
+      if (ctx) {
+        ctx.save();
+        ctx.translate(canvasWidth / 2, canvasHeight / 2);
+        applyActorTransformToContext(ctx, transform);
+        ctx.drawImage(imgEl, -imgWidth / 2, -imgHeight / 2);
+        ctx.restore();
+
+        const dragImage = new Image();
+        dragImage.src = canvas.toDataURL();
+
+        // Adjust drag offset for rotated images
+        let adjustedDragLeft = dragLeft;
+        let adjustedDragTop = dragTop;
+        if (needsSwap) {
+          // When rotated 90/270 degrees, swap and adjust the drag offset
+          if (transform === "90") {
+            adjustedDragLeft = dragTop;
+            adjustedDragTop = imgWidth - dragLeft;
+          } else if (transform === "270") {
+            adjustedDragLeft = imgHeight - dragTop;
+            adjustedDragTop = dragLeft;
+          } else if (transform === "d1") {
+            adjustedDragLeft = dragTop;
+            adjustedDragTop = dragLeft;
+          } else if (transform === "d2") {
+            adjustedDragLeft = imgHeight - dragTop;
+            adjustedDragTop = imgWidth - dragLeft;
+          }
+        }
+
+        event.dataTransfer.setDragImage(dragImage, adjustedDragLeft, adjustedDragTop);
+      }
+    }
   };
 
   let data = new URL("../../img/splat.png", import.meta.url).href;

--- a/frontend/src/editor/utils/stage-helpers.ts
+++ b/frontend/src/editor/utils/stage-helpers.ts
@@ -301,6 +301,44 @@ export function applyActorTransformToContext(
   }
 }
 
+/**
+ * Returns whether the given transform swaps width and height dimensions.
+ * This is true for 90°, 270°, and diagonal reflections.
+ */
+export function transformSwapsDimensions(transform: ActorTransform): boolean {
+  return transform === "90" || transform === "270" || transform === "d1" || transform === "d2";
+}
+
+/**
+ * Renders an image with the given transform applied to a new canvas.
+ * Returns the canvas element with the transformed image drawn on it.
+ */
+export function renderTransformedImage(
+  img: CanvasImageSource,
+  imgWidth: number,
+  imgHeight: number,
+  transform: ActorTransform,
+): HTMLCanvasElement {
+  const needsSwap = transformSwapsDimensions(transform);
+  const canvasWidth = needsSwap ? imgHeight : imgWidth;
+  const canvasHeight = needsSwap ? imgWidth : imgHeight;
+
+  const canvas = document.createElement("canvas");
+  canvas.width = canvasWidth;
+  canvas.height = canvasHeight;
+  const ctx = canvas.getContext("2d");
+
+  if (ctx) {
+    ctx.save();
+    ctx.translate(canvasWidth / 2, canvasHeight / 2);
+    applyActorTransformToContext(ctx, transform);
+    ctx.drawImage(img, -imgWidth / 2, -imgHeight / 2);
+    ctx.restore();
+  }
+
+  return canvas;
+}
+
 export function getStageScreenshot(stage: Stage, { size }: { size: number }) {
   const { characters } = window.editorStore.getState();
 


### PR DESCRIPTION
When dragging an actor with a transformed appearance (rotated or flipped),
the drag preview was garbled because the browser was capturing the DOM element
with CSS transforms applied, which doesn't render correctly as a drag image.

This fix creates a canvas-rendered drag image with the transform properly
applied using applyActorTransformToContext, matching how other parts of the
codebase (like stage screenshots) render transformed actors. The drag offset
is also adjusted for rotated images so the cursor position remains accurate.