### PR TITLE
Fix rule and appearance tools to reset on background click

### DIFF
--- a/frontend/src/editor/components/stage/stage.tsx
+++ b/frontend/src/editor/components/stage/stage.tsx
@@ -587,7 +587,12 @@ export const Stage = ({
       setSelectionRect(null);
     }
     if (!event.shiftKey && !event.defaultPrevented) {
-      if (TOOLS.TRASH === selectedToolId || TOOLS.STAMP === selectedToolId) {
+      if (
+        TOOLS.TRASH === selectedToolId ||
+        TOOLS.STAMP === selectedToolId ||
+        TOOLS.RECORD === selectedToolId ||
+        TOOLS.PAINT === selectedToolId
+      ) {
         dispatch(selectToolId(TOOLS.POINTER));
       }
     }


### PR DESCRIPTION
Add RECORD and PAINT tools to the condition in onMouseUp that resets
the selected tool to POINTER when clicking on empty stage background.
This makes them consistent with TRASH and STAMP tools which already
had this behavior.