### PR TITLE
Add actor selection dropdown for overlapping actors

### DIFF
--- a/frontend/src/editor/components/sprites/actor-sprite.tsx
+++ b/frontend/src/editor/components/sprites/actor-sprite.tsx
@@ -18,6 +18,7 @@ const ActorSprite = (props: {
   onClick?: (e: React.MouseEvent) => void;
   onMouseUp?: (e: React.MouseEvent) => void;
   onDoubleClick?: (e: React.MouseEvent) => void;
+  onDragStart?: (e: React.DragEvent) => void;
   transitionDuration?: number;
 }) => {
   const {
@@ -29,6 +30,7 @@ const ActorSprite = (props: {
     onClick,
     onMouseUp,
     onDoubleClick,
+    onDragStart: onDragStartProp,
   } = props;
 
   if (!character) {
@@ -140,6 +142,8 @@ const ActorSprite = (props: {
 
       event.dataTransfer.setDragImage(dragImage, adjustedDragLeft, adjustedDragTop);
     }
+
+    onDragStartProp?.(event);
   };
 
   let data = new URL("../../img/splat.png", import.meta.url).href;

--- a/frontend/src/editor/components/stage/actor-selection-popover.tsx
+++ b/frontend/src/editor/components/stage/actor-selection-popover.tsx
@@ -1,0 +1,102 @@
+import React, { useEffect, useRef } from "react";
+import { Actor, Characters } from "../../../types";
+import ActorSprite from "../sprites/actor-sprite";
+import { STAGE_CELL_SIZE } from "../../constants/constants";
+
+interface ActorSelectionPopoverProps {
+  actors: Actor[];
+  characters: Characters;
+  position: { x: number; y: number }; // Screen pixel position for popover
+  onSelect: (actor: Actor) => void;
+  onDragStart: (actor: Actor) => void;
+  onClose: () => void;
+}
+
+const ActorSelectionPopover: React.FC<ActorSelectionPopoverProps> = ({
+  actors,
+  characters,
+  position,
+  onSelect,
+  onDragStart,
+  onClose,
+}) => {
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (popoverRef.current && !popoverRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+
+    // Delay adding listener to avoid immediate close from the triggering click
+    const timeoutId = setTimeout(() => {
+      document.addEventListener("mousedown", handleClickOutside);
+      document.addEventListener("keydown", handleKeyDown);
+    }, 0);
+
+    return () => {
+      clearTimeout(timeoutId);
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [onClose]);
+
+  // Calculate popover position, keeping it on screen
+  const popoverStyle: React.CSSProperties = {
+    position: "fixed",
+    left: position.x,
+    top: position.y + 10,
+    zIndex: 1000,
+  };
+
+  return (
+    <div ref={popoverRef} className="actor-selection-popover" style={popoverStyle}>
+      <div className="actor-selection-popover-content">
+        {actors.map((actor) => {
+          const character = characters[actor.characterId];
+          if (!character) return null;
+
+          return (
+            <div
+              key={actor.id}
+              className="actor-option"
+              style={{
+                width: STAGE_CELL_SIZE + 8,
+                height: STAGE_CELL_SIZE + 8,
+                position: "relative",
+              }}
+            >
+              <div
+                style={{
+                  position: "absolute",
+                  left: 4,
+                  top: 4,
+                  width: STAGE_CELL_SIZE,
+                  height: STAGE_CELL_SIZE,
+                }}
+              >
+                <ActorSprite
+                  character={character}
+                  actor={{ ...actor, position: { x: 0, y: 0 } }}
+                  selected={false}
+                  dragActorIds={[actor.id]}
+                  onMouseUp={() => onSelect(actor)}
+                  onDragStart={() => onDragStart(actor)}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default ActorSelectionPopover;

--- a/frontend/src/editor/components/stage/actor-selection-popover.tsx
+++ b/frontend/src/editor/components/stage/actor-selection-popover.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useRef } from "react";
 import { Actor, Characters } from "../../../types";
-import ActorSprite from "../sprites/actor-sprite";
 import { STAGE_CELL_SIZE } from "../../constants/constants";
+import ActorSprite from "../sprites/actor-sprite";
+import { DEFAULT_APPEARANCE_INFO } from "../sprites/sprite";
 
 interface ActorSelectionPopoverProps {
   actors: Actor[];
@@ -61,6 +62,9 @@ const ActorSelectionPopover: React.FC<ActorSelectionPopoverProps> = ({
       <div className="actor-selection-popover-content">
         {actors.map((actor) => {
           const character = characters[actor.characterId];
+          const { appearances, appearanceInfo } = character.spritesheet;
+          const info = appearanceInfo?.[actor.appearance] || DEFAULT_APPEARANCE_INFO;
+
           if (!character) return null;
 
           return (
@@ -68,20 +72,12 @@ const ActorSelectionPopover: React.FC<ActorSelectionPopoverProps> = ({
               key={actor.id}
               className="actor-option"
               style={{
-                width: STAGE_CELL_SIZE + 8,
-                height: STAGE_CELL_SIZE + 8,
-                position: "relative",
+                width: info.width * STAGE_CELL_SIZE + 8,
+                height: info.height * STAGE_CELL_SIZE + 8,
+                padding: 2,
               }}
             >
-              <div
-                style={{
-                  position: "absolute",
-                  left: 4,
-                  top: 4,
-                  width: STAGE_CELL_SIZE,
-                  height: STAGE_CELL_SIZE,
-                }}
-              >
+              <div style={{ position: "relative" }}>
                 <ActorSprite
                   character={character}
                   actor={{ ...actor, position: { x: 0, y: 0 } }}

--- a/frontend/src/editor/styles/editor.scss
+++ b/frontend/src/editor/styles/editor.scss
@@ -799,6 +799,36 @@ html {
   }
 }
 
+.actor-selection-popover {
+  background: white;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  padding: 6px;
+
+  .actor-selection-popover-content {
+    display: flex;
+    gap: 4px;
+  }
+
+  .actor-option {
+    cursor: pointer;
+    border: 2px solid transparent;
+    border-radius: 4px;
+    background: #f5f5f5;
+    transition: border-color 0.1s, background-color 0.1s;
+
+    &:hover {
+      border-color: #007bff;
+      background: rgba(0, 123, 255, 0.1);
+    }
+
+    img {
+      pointer-events: auto;
+    }
+  }
+}
+
 .tool-trash {
   .variables-grid {
     .variable-box:hover {

--- a/frontend/src/editor/utils/stage-helpers.ts
+++ b/frontend/src/editor/utils/stage-helpers.ts
@@ -34,6 +34,14 @@ export function actorFillsPoint(actor: Actor, characters: Characters, point: Pos
   return actorFilledPoints(actor, characters).some((p) => p.x === point.x && p.y === point.y);
 }
 
+export function actorsAtPoint(
+  actors: { [id: string]: Actor },
+  characters: Characters,
+  point: Position,
+): Actor[] {
+  return Object.values(actors).filter((actor) => actorFillsPoint(actor, characters, point));
+}
+
 export function actorIntersectsExtent(actor: Actor, characters: Characters, extent: RuleExtent) {
   const points = new Set(actorFilledPoints(actor, characters).map((p) => `${p.x},${p.y}`));
   for (let x = extent.xmin; x <= extent.xmax; x++) {


### PR DESCRIPTION
When multiple actors occupy the same grid square, clicking now shows a
popover with all actors at that position. Users can click to select or
drag directly from the popover to interact with a specific actor.