### PR TITLE
Add more granular rule evaluation tracking, show conditions and squares that don't match

### DIFF
--- a/.claude/skills/world-operator/SKILL.md
+++ b/.claude/skills/world-operator/SKILL.md
@@ -53,7 +53,7 @@ World (complete state)
   ├── stages: {[id]: Stage}
   ├── globals                    # Global variables
   ├── input: {keys, clicks}      # Current frame input
-  ├── evaluatedRuleIds           # Debug: which rules fired
+  ├── evaluatedRuleDetails       # Debug: detailed rule evaluation results
   ├── evaluatedTickFrames        # Debug: animation frames
   └── history: HistoryItem[]     # Undo stack (max 20)
 ```
@@ -140,11 +140,17 @@ Returns `{ruleActorId → stageActor}` mapping, or `false`.
 
 ## Debug Data
 
-### evaluatedRuleIds
+### evaluatedRuleDetails
 ```typescript
-{ [actorId]: { [ruleId]: boolean } }
+{ [actorId]: { [ruleId]: EvaluatedRuleDetails } }
 ```
-Tracks which rules fired for each actor. Used by inspector to show rule state circles.
+Tracks detailed evaluation results for each rule per actor. Includes:
+- Overall pass/fail status
+- Per-square matching results (with failure reasons)
+- Per-condition evaluation results (with resolved values)
+- Actor mappings (which stage actor matched which rule actor)
+
+Used by inspector to show rule state circles and condition status dots. See `granular-rule-tracking.md` for full details.
 
 ### evaluatedTickFrames
 ```typescript
@@ -163,4 +169,5 @@ Animation frames within a tick. Stage container animates through these.
 
 ## See Also
 
-For detailed architecture diagrams, data flow, and code examples, see `architecture-reference.md` in this skill folder.
+- `architecture-reference.md` - Detailed architecture diagrams, data flow, and code examples
+- `granular-rule-tracking.md` - Documentation for the granular rule evaluation tracking system (square/condition-level feedback)

--- a/.claude/skills/world-operator/granular-rule-tracking.md
+++ b/.claude/skills/world-operator/granular-rule-tracking.md
@@ -1,0 +1,242 @@
+# Granular Rule Evaluation Tracking
+
+This document describes the granular rule evaluation tracking system, which provides detailed feedback about why rules pass or fail.
+
+## Overview
+
+The system tracks evaluation results at three levels of granularity:
+
+1. **Rule level**: Did the rule pass/fail overall?
+2. **Square level**: Did each grid square in the "before" pattern match?
+3. **Condition level**: Did each individual condition pass/fail?
+
+This replaces the simpler `evaluatedRuleIds: { [actorId]: { [ruleId]: boolean } }` with the more detailed `evaluatedRuleDetails` map.
+
+## Types (`types.ts`)
+
+```typescript
+/** Detailed evaluation result for a single condition */
+type EvaluatedCondition = {
+  conditionKey: string;
+  passed: boolean;
+  leftValue?: string | null;   // Resolved value for debugging
+  rightValue?: string | null;  // Resolved value for debugging
+};
+
+/** Detailed evaluation result for a single extent square */
+type EvaluatedSquare = {
+  x: number;  // Relative to rule extent (not absolute stage position)
+  y: number;
+  passed: boolean;
+  reason?: "offscreen" | "actor-count-mismatch" | "actor-match-failed" | "ok";
+  expectedActorCount?: number;
+  actualActorCount?: number;
+};
+
+/** Detailed evaluation result for a rule */
+type EvaluatedRuleDetails = {
+  passed: boolean;
+  failedAt?: "extent-square" | "missing-required-actor" | "action-offset-invalid" | "condition-failed";
+  conditions: EvaluatedCondition[];
+  squares: EvaluatedSquare[];
+  matchedActors: { [ruleActorId: string]: string };  // ruleActorId -> stageActorId
+};
+
+/** Granular evaluation data per actor per rule */
+type EvaluatedRuleDetailsMap = {
+  [actorId: string]: {
+    [ruleId: string]: EvaluatedRuleDetails;
+  };
+};
+```
+
+## Two-Phase Actor Matching
+
+The `checkRuleScenario` function uses a two-phase matching strategy when checking if stage actors match rule actors:
+
+### Phase 1: Full Match (Character + Conditions)
+Uses `actorsMatch()` which checks:
+1. Character ID must match
+2. All conditions referencing the actor must pass
+
+This is needed to **disambiguate** when multiple actors of the same character exist in a rule. For example, if a rule has two zombies with different appearances, conditions help determine which stage zombie corresponds to which rule zombie.
+
+### Phase 2: Character-Only Fallback
+If no full match is found, tries matching by character ID only.
+
+This provides better **UI feedback**: squares show green when the right character is present, even if conditions fail. Conditions are then evaluated separately and shown with their own status indicators.
+
+```typescript
+// In checkRuleScenario, for each stage actor at a position:
+let match = ruleActorsAtPos.find((r) =>
+  actorsMatch(s, r, rule.conditions, stageActorsForReferencedActorId),
+);
+
+// Fallback: character-only match for UI feedback
+if (!match) {
+  match = ruleActorsAtPos.find(
+    (r) => r.characterId === s.characterId && !ruleActorsUsed.has(...),
+  );
+}
+```
+
+**Key insight**: For actual rule execution, the full match with conditions is still required - a rule won't fire unless all conditions pass. The fallback only improves diagnostic feedback shown in the UI.
+
+## Evaluation Flow in checkRuleScenario
+
+```
+1. For each (x, y) in rule.extent:
+   ├─ Check position validity → may add square with reason="offscreen"
+   ├─ Check actor counts → may add square with reason="actor-count-mismatch"
+   └─ Match actors (two-phase) → may add square with reason="actor-match-failed" or "ok"
+
+2. Check required actors found → may set failedAt="missing-required-actor"
+
+3. Check action offsets valid → may set failedAt="action-offset-invalid"
+
+4. Evaluate ALL conditions (if actors matched):
+   For each condition:
+   ├─ Resolve left and right values
+   ├─ Check if comparator matches
+   └─ Add to conditions[] with passed status
+
+5. Return details with all collected data
+```
+
+## Data Storage
+
+Evaluation details are stored per-actor per-rule and always updated (no stale data):
+
+```typescript
+// In tickRulesTree, after evaluating each rule:
+evaluatedRuleDetails[me.id] = evaluatedRuleDetails[me.id] || {};
+evaluatedRuleDetails[me.id][rule.id] = details;  // Always update
+```
+
+**Important**: Previously, details were only updated when `passed === true`, which caused stale data when a previously-passing rule started failing.
+
+## UI Integration
+
+### InspectorContext
+
+Provides `evaluatedRuleDetailsForActor` (the per-rule details for the selected actor):
+
+```typescript
+const InspectorContext = React.createContext<{
+  world: WorldMinimal;
+  characters: Characters;
+  evaluatedRuleDetailsForActor: EvaluatedRuleDetailsMap[""];  // { [ruleId]: EvaluatedRuleDetails }
+}>();
+```
+
+### Rule State Circle (`rule-state-circle.tsx`)
+
+Shows overall pass/fail for a rule:
+
+```typescript
+const RuleStateCircle = ({ rule }) => {
+  const { evaluatedRuleDetailsForActor } = useContext(InspectorContext);
+  const details = evaluatedRuleDetailsForActor?.[rule.id];
+  return <div className={`circle ${details?.passed}`} />;
+};
+```
+
+### Condition Status Dots
+
+Both the recording panel and right sidebar show per-condition status:
+
+```typescript
+// Build condition status map
+const conditionStatusMap: { [conditionKey: string]: EvaluatedCondition } = {};
+const ruleDetails = evaluatedRuleDetailsForActor?.[rule.id];
+if (ruleDetails?.conditions) {
+  for (const cond of ruleDetails.conditions) {
+    conditionStatusMap[cond.conditionKey] = cond;
+  }
+}
+
+// Pass to each condition row
+<FreeformConditionRow
+  condition={condition}
+  conditionStatus={conditionStatusMap[condition.key]}
+  ...
+/>
+```
+
+### Square Status Overlay (`recording-square-status.tsx`)
+
+Renders colored overlays on the "before" stage when editing a rule:
+
+```typescript
+const RecordingSquareStatus = ({ squares, extentXMin, extentYMin }) => (
+  <>
+    {squares.map((square) => {
+      const x = extentXMin + square.x;
+      const y = extentYMin + square.y;
+      const color = square.passed
+        ? "rgba(116, 229, 53, 0.35)"  // green
+        : "rgba(255, 0, 0, 0.35)";    // red
+      return (
+        <div
+          key={`square-status-${square.x}-${square.y}`}
+          style={{
+            position: "absolute",
+            left: x * STAGE_CELL_SIZE,
+            top: y * STAGE_CELL_SIZE,
+            width: STAGE_CELL_SIZE,
+            height: STAGE_CELL_SIZE,
+            backgroundColor: color,
+            pointerEvents: "none",
+            zIndex: 10,
+          }}
+        />
+      );
+    })}
+  </>
+);
+```
+
+### Getting Square Data for UI
+
+The `StageContainer` passes `evaluatedSquares` to the `Stage` component only for the "before" stage during rule editing:
+
+```typescript
+function getEvaluatedSquares(
+  ruleId: string | null,
+  evaluatedRuleDetails: EvaluatedRuleDetailsMap,
+  selectedActors: UIState["selectedActors"],
+): EvaluatedSquare[] {
+  if (!ruleId) return [];
+
+  // Find actor with evaluation data for this rule
+  // (tries selected actor first, then falls back to any actor)
+  const evalActorId = findActorWithRuleData(ruleId, evaluatedRuleDetails, selectedActors);
+
+  return evaluatedRuleDetails[evalActorId]?.[ruleId]?.squares ?? [];
+}
+```
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `types.ts` | Type definitions for EvaluatedCondition, EvaluatedSquare, EvaluatedRuleDetails |
+| `world-operator.ts` | checkRuleScenario returns detailed results, tickRulesTree stores them |
+| `inspector-context.tsx` | Provides evaluatedRuleDetailsForActor to inspector components |
+| `content-rule.tsx` | Shows condition status in right sidebar |
+| `content-flow-group-check.tsx` | Shows condition status for flow group checks |
+| `panel-conditions.tsx` | Shows condition status in recording panel |
+| `recording-square-status.tsx` | Renders square overlays on before stage |
+| `stage/container.tsx` | Computes evaluatedSquares and passes to Stage |
+| `stage.tsx` | Renders RecordingSquareStatus when evaluatedSquares provided |
+
+## Edge Cases
+
+### Multiple Actors of Same Character
+When a rule has two actors of the same character (e.g., two zombies), conditions are used to disambiguate which stage actor maps to which rule actor. If conditions fail, the character-only fallback ensures the square still shows as "passed" while condition dots show the specific failure.
+
+### Conditions Referencing Other Actors
+Some conditions compare values between two different actors (e.g., `zombie1.health > zombie2.health`). The `stageActorsForReferencedActorId` function handles lookups for the RHS actor, using matched actors when available.
+
+### Stale Data Prevention
+The evaluation details are always updated on each tick, not just when a rule passes. This prevents stale "passing" indicators from persisting when a rule starts failing.

--- a/PLAN-granular-rule-tracking.md
+++ b/PLAN-granular-rule-tracking.md
@@ -1,0 +1,348 @@
+# Plan: Granular Rule Evaluation Tracking
+
+## Goal
+Enhance the rule evaluation system to track **why** a rule didn't match, not just **whether** it matched. This enables the UI to display per-condition and per-square status indicators instead of just a single rule-level dot.
+
+## Current State
+
+### Data Structure
+```typescript
+// types.ts
+export type EvaluatedRuleIds = {
+  [actorId: string]: {
+    [ruleTreeItemId: string]: boolean;  // Only tracks: matched or not
+  };
+};
+```
+
+### Matching Flow in `checkRuleScenario()` (world-operator.ts:212-346)
+1. Iterate through each position `(x, y)` in `rule.extent`
+2. Find stage actors at that position
+3. Check if actor count matches rule expectations
+4. Match stage actors to rule actors using `actorsMatch()`
+5. Verify all required actors were found
+6. Check action offsets are valid
+7. Re-check all conditions (global-to-global, etc.)
+
+The function returns `false` at multiple points without indicating **which** check failed.
+
+---
+
+## Proposed Design
+
+### New Type Definitions
+
+```typescript
+// types.ts - Add these new types
+
+/** Detailed evaluation result for a single condition */
+export type EvaluatedCondition = {
+  conditionKey: string;
+  passed: boolean;
+  leftValue?: string | null;   // Resolved value (for debugging/display)
+  rightValue?: string | null;  // Resolved value (for debugging/display)
+};
+
+/** Detailed evaluation result for a single extent square */
+export type EvaluatedSquare = {
+  x: number;
+  y: number;
+  passed: boolean;
+  reason?:
+    | "offscreen"              // Position is offscreen on non-wrapping stage
+    | "actor-count-mismatch"   // Different number of actors than expected
+    | "actor-match-failed"     // Actor exists but doesn't match rule actor
+    | "ok";                    // Square passed
+  expectedActorCount?: number;
+  actualActorCount?: number;
+};
+
+/** Detailed evaluation result for a rule */
+export type EvaluatedRuleDetails = {
+  passed: boolean;
+
+  // Which stage of checking caused failure (for quick diagnosis)
+  failedAt?:
+    | "extent-square"          // A square in the extent didn't match
+    | "missing-required-actor" // A required actor wasn't found
+    | "action-offset-invalid"  // An action would go offscreen
+    | "condition-failed";      // A condition check failed
+
+  // Detailed breakdown
+  conditions: EvaluatedCondition[];
+  squares: EvaluatedSquare[];
+
+  // Which actors were successfully matched (ruleActorId -> stageActorId)
+  matchedActors?: { [ruleActorId: string]: string };
+};
+
+/** Enhanced EvaluatedRuleIds with optional granular data */
+export type EvaluatedRuleIds = {
+  [actorId: string]: {
+    [ruleTreeItemId: string]: boolean;
+  };
+};
+
+/** New: Granular evaluation data stored separately */
+export type EvaluatedRuleDetails = {
+  [actorId: string]: {
+    [ruleId: string]: EvaluatedRuleDetails;
+  };
+};
+```
+
+### World State Changes
+
+```typescript
+// types.ts - Update WorldMinimal
+export type WorldMinimal = {
+  // ... existing fields ...
+  evaluatedRuleIds: EvaluatedRuleIds;
+  evaluatedRuleDetails?: EvaluatedRuleDetails;  // NEW: Optional granular data
+};
+```
+
+---
+
+## Implementation Steps
+
+### Step 1: Define New Types (types.ts)
+Add the new type definitions for granular tracking:
+- `EvaluatedCondition`
+- `EvaluatedSquare`
+- `EvaluatedRuleDetails`
+- Update `WorldMinimal` to include optional `evaluatedRuleDetails`
+
+### Step 2: Refactor `checkRuleScenario()` (world-operator.ts)
+
+**Current signature:**
+```typescript
+function checkRuleScenario(
+  rule: Rule | NonNullable<RuleTreeFlowItem["check"]>,
+): { [ruleActorId: string]: Actor } | false
+```
+
+**New signature:**
+```typescript
+type CheckRuleScenarioResult = {
+  passed: boolean;
+  stageActorForId: { [ruleActorId: string]: Actor } | null;
+  details: EvaluatedRuleDetails;
+};
+
+function checkRuleScenario(
+  rule: Rule | NonNullable<RuleTreeFlowItem["check"]>,
+): CheckRuleScenarioResult
+```
+
+**Implementation changes:**
+1. Initialize `details` object at start
+2. Track each square evaluation in `details.squares`
+3. Track each condition evaluation in `details.conditions`
+4. Instead of `return false`, populate `details.failedAt` and return full result
+5. At end, return `{ passed: true, stageActorForId, details }`
+
+### Step 3: Refactor `actorsMatch()` (world-operator.ts)
+
+**Current signature:**
+```typescript
+function actorsMatch(
+  stageActor: Actor,
+  ruleActor: Actor,
+  conditions: RuleCondition[],
+  stageActorsForId: ActorLookupFn | "avoiding-recursion",
+): boolean
+```
+
+**Option A (simpler):** Keep returning boolean, let `checkRuleScenario` track which actor-pair failed.
+
+**Option B (more granular):** Return detailed match info:
+```typescript
+type ActorMatchResult = {
+  matched: boolean;
+  failedConditions?: string[];  // condition keys that failed
+};
+```
+
+**Recommendation:** Start with Option A for simplicity. We can enhance later if needed.
+
+### Step 4: Update `tickRule()` and `tickRulesTree()`
+
+Store the `EvaluatedRuleDetails` in a new module-level variable:
+```typescript
+let evaluatedRuleDetails: EvaluatedRuleDetails = {};
+```
+
+After `checkRuleScenario()` returns, store the details:
+```typescript
+const result = checkRuleScenario(rule);
+evaluatedRuleDetails[me.id] = evaluatedRuleDetails[me.id] || {};
+evaluatedRuleDetails[me.id][rule.id] = result.details;
+```
+
+### Step 5: Update `tick()` Return Value
+
+Add `evaluatedRuleDetails` to the returned world state:
+```typescript
+return u({
+  // ... existing fields ...
+  evaluatedRuleIds: u.constant(evaluatedRuleIds),
+  evaluatedRuleDetails: u.constant(evaluatedRuleDetails),  // NEW
+}, previousWorld);
+```
+
+### Step 6: Update History Tracking
+
+Add `evaluatedRuleDetails` to `HistoryItem` type and store/restore it in `tick()`/`untick()`.
+
+### Step 7: Update Context Provider (inspector/container.tsx)
+
+Pass granular data through context:
+```typescript
+<InspectorContext.Provider
+  value={{
+    evaluatedRuleIdsForActor: focusedActor
+      ? focusedWorld.evaluatedRuleIds[focusedActor.id]
+      : {},
+    evaluatedRuleDetailsForActor: focusedActor  // NEW
+      ? focusedWorld.evaluatedRuleDetails?.[focusedActor.id]
+      : {},
+  }}
+>
+```
+
+### Step 8: Create New UI Components
+
+**ConditionStateCircle** (new file):
+```tsx
+export const ConditionStateCircle = ({ ruleId, conditionKey }: Props) => {
+  const { evaluatedRuleDetailsForActor } = useContext(InspectorContext);
+  const details = evaluatedRuleDetailsForActor?.[ruleId];
+  const condition = details?.conditions.find(c => c.conditionKey === conditionKey);
+  const passed = condition?.passed;
+  return <div className={`circle ${passed}`} />;
+};
+```
+
+**SquareStateIndicator** (new file):
+```tsx
+// For displaying in rule mini-preview, etc.
+export const SquareStateIndicator = ({ ruleId, x, y }: Props) => {
+  const { evaluatedRuleDetailsForActor } = useContext(InspectorContext);
+  const details = evaluatedRuleDetailsForActor?.[ruleId];
+  const square = details?.squares.find(s => s.x === x && s.y === y);
+  // Return visual indicator with color based on square.passed and square.reason
+};
+```
+
+### Step 9: Integrate into Existing UI
+
+Update `ContentRule`, `ContentConditions`, and rule preview components to show:
+- Per-condition status dots next to each condition row
+- Visual overlay on rule "before" picture showing which squares matched/failed
+
+---
+
+## File Changes Summary
+
+| File | Changes |
+|------|---------|
+| `frontend/src/types.ts` | Add new types, update WorldMinimal, HistoryItem |
+| `frontend/src/editor/utils/world-operator.ts` | Refactor `checkRuleScenario()`, add details tracking |
+| `frontend/src/editor/components/inspector/inspector-context.tsx` | Add `evaluatedRuleDetailsForActor` to context |
+| `frontend/src/editor/components/inspector/container.tsx` | Pass details through context |
+| `frontend/src/editor/components/inspector/condition-state-circle.tsx` | New component |
+| `frontend/src/editor/components/inspector/square-state-indicator.tsx` | New component |
+| `frontend/src/editor/components/inspector/content-rule.tsx` | Use new indicators |
+
+---
+
+## Performance Considerations
+
+1. **Memory**: Storing detailed evaluation data increases memory usage. Consider:
+   - Only track details in "debug mode" or when inspector is open
+   - Limit history depth for detailed data
+   - Use more compact representations
+
+2. **Computation**: Tracking details adds overhead. The current implementation already does all these checks - we're just recording results instead of discarding them.
+
+3. **Optional Tracking**: Add a flag to enable/disable granular tracking:
+   ```typescript
+   function tick(options?: { trackDetails?: boolean })
+   ```
+
+---
+
+## Testing Strategy
+
+1. Unit tests for `checkRuleScenario()` verifying correct detail population
+2. Test each failure mode returns appropriate `failedAt` and details
+3. Integration tests verifying UI displays correct status
+4. Performance benchmarks comparing with/without detail tracking
+
+---
+
+## Open Questions
+
+1. **Should we track actor-level match details?** Currently proposed to track at square level. Could go deeper to track which specific property (appearance, variable, etc.) caused actor mismatch.
+
+2. **Should details persist in saved worlds?** Probably not - they're runtime evaluation state only.
+
+3. **How to visualize square failures in UI?** Options:
+   - Color overlay on rule preview tiles
+   - Tooltip on hover
+   - Separate debug panel
+
+4. **Should flow containers (group-event, group-flow) also have detailed tracking?** Currently proposed for rules only. Could extend to show which child rules were attempted.
+
+---
+
+## Architectural Insights (from world-operator skill)
+
+### Pattern to Follow: FrameAccumulator
+
+The existing `FrameAccumulator` class tracks animation frames during rule execution. We can follow a similar pattern for tracking evaluation details:
+
+```typescript
+// Similar to how FrameAccumulator works
+class EvaluationAccumulator {
+  private details: { [actorId: string]: { [ruleId: string]: EvaluatedRuleDetails } } = {};
+
+  push(actorId: string, ruleId: string, result: EvaluatedRuleDetails) {
+    this.details[actorId] ||= {};
+    this.details[actorId][ruleId] = result;
+  }
+
+  getDetails() { return this.details; }
+}
+```
+
+### Key Code Points (from architecture reference)
+
+1. **checkRuleScenario failure points** (world-operator.ts:212-346):
+   - Line 269: `wrappedStagePos === null` → offscreen
+   - Line 282: actor count mismatch
+   - Line 296: no matching rule actor found
+   - Line 305: required actor not found
+   - Line 316: action offset invalid
+   - Line 341: condition check failed
+
+2. **actorsMatch failure points** (world-operator.ts:66-118):
+   - Line 73: character mismatch
+   - Line 114: condition comparison failed
+
+3. **UI integration point** (inspector/rule-state-circle.tsx):
+   - Uses `InspectorContext` to get `evaluatedRuleIdsForActor`
+   - Simple lookup: `evaluatedRuleIdsForActor?.[rule.id]`
+   - We add `evaluatedRuleDetailsForActor` following the same pattern
+
+### Immutable Update Pattern
+
+Follow existing updeep pattern:
+```typescript
+return u({
+  // ... existing fields ...
+  evaluatedRuleIds: u.constant(evaluatedRuleIds),
+  evaluatedRuleDetails: u.constant(evaluatedRuleDetails),  // NEW
+}, previousWorld);
+```

--- a/frontend/src/editor/components/inspector/container.tsx
+++ b/frontend/src/editor/components/inspector/container.tsx
@@ -53,8 +53,8 @@ export const InspectorContainer = () => {
       value={{
         world: focusedWorld,
         characters: characters,
-        evaluatedRuleIdsForActor: focusedActor
-          ? focusedWorld.evaluatedRuleIds[focusedActor.id]
+        evaluatedRuleDetailsForActor: focusedActor
+          ? focusedWorld.evaluatedRuleDetails[focusedActor.id]
           : {},
       }}
     >

--- a/frontend/src/editor/components/inspector/content-flow-group-check.tsx
+++ b/frontend/src/editor/components/inspector/content-flow-group-check.tsx
@@ -2,12 +2,21 @@ import React, { useContext } from "react";
 
 import { ScenarioStage } from "./scenario-stage";
 
-import { RuleTreeFlowItemCheck } from "../../../types";
+import { EvaluatedCondition, RuleTreeFlowItemCheck } from "../../../types";
 import { FreeformConditionRow } from "../stage/recording/condition-rows";
 import { InspectorContext } from "./inspector-context";
 
 export const ContentFlowGroupCheck = ({ check }: { check: RuleTreeFlowItemCheck }) => {
-  const { characters, world } = useContext(InspectorContext);
+  const { characters, world, evaluatedRuleDetailsForActor } = useContext(InspectorContext);
+
+  // Build condition status map from evaluation details
+  const conditionStatusMap: { [conditionKey: string]: EvaluatedCondition } = {};
+  const checkDetails = evaluatedRuleDetailsForActor?.[check.id];
+  if (checkDetails?.conditions) {
+    for (const cond of checkDetails.conditions) {
+      conditionStatusMap[cond.conditionKey] = cond;
+    }
+  }
 
   const conditions: React.ReactNode[] = [];
   check.conditions.forEach((condition) => {
@@ -19,6 +28,7 @@ export const ContentFlowGroupCheck = ({ check }: { check: RuleTreeFlowItemCheck 
           world={world}
           condition={condition}
           characters={characters}
+          conditionStatus={conditionStatusMap[condition.key]}
         />,
       );
     }

--- a/frontend/src/editor/components/inspector/content-rule.tsx
+++ b/frontend/src/editor/components/inspector/content-rule.tsx
@@ -5,7 +5,7 @@ import { DisclosureTriangle } from "./disclosure-triangle";
 import { RuleStateCircle } from "./rule-state-circle";
 import { ScenarioStage } from "./scenario-stage";
 
-import { Rule } from "../../../types";
+import { EvaluatedCondition, Rule } from "../../../types";
 import { FreeformConditionRow } from "../stage/recording/condition-rows";
 import { isCollapsePersisted, persistCollapsedState } from "./collapse-state-storage";
 import { RuleActionsContext } from "./container-pane-rules";
@@ -13,12 +13,21 @@ import { InspectorContext } from "./inspector-context";
 
 export const ContentRule = ({ rule }: { rule: Rule }) => {
   const [collapsed, setCollapsed] = useState(isCollapsePersisted(rule.id));
-  const { characters, world } = useContext(InspectorContext);
+  const { characters, world, evaluatedRuleDetailsForActor } = useContext(InspectorContext);
   const { onRuleChanged } = useContext(RuleActionsContext);
 
   const _onNameChange = (name: string) => {
     onRuleChanged(rule.id, { name });
   };
+
+  // Build condition status map from evaluation details
+  const conditionStatusMap: { [conditionKey: string]: EvaluatedCondition } = {};
+  const ruleDetails = evaluatedRuleDetailsForActor?.[rule.id];
+  if (ruleDetails?.conditions) {
+    for (const cond of ruleDetails.conditions) {
+      conditionStatusMap[cond.conditionKey] = cond;
+    }
+  }
 
   const conditions: React.ReactNode[] = [];
   rule.conditions.forEach((condition) => {
@@ -30,6 +39,7 @@ export const ContentRule = ({ rule }: { rule: Rule }) => {
           world={world}
           condition={condition}
           characters={characters}
+          conditionStatus={conditionStatusMap[condition.key]}
         />,
       );
     }

--- a/frontend/src/editor/components/inspector/inspector-context.tsx
+++ b/frontend/src/editor/components/inspector/inspector-context.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import { Characters, EvaluatedRuleIds, WorldMinimal } from "../../../types";
+import { Characters, EvaluatedRuleDetailsMap, WorldMinimal } from "../../../types";
 
 export const InspectorContext = React.createContext<{
   world: WorldMinimal;
   characters: Characters;
-  evaluatedRuleIdsForActor: EvaluatedRuleIds[""];
+  evaluatedRuleDetailsForActor: EvaluatedRuleDetailsMap[""];
 }>(new Error() as never);

--- a/frontend/src/editor/components/inspector/rule-state-circle.tsx
+++ b/frontend/src/editor/components/inspector/rule-state-circle.tsx
@@ -2,7 +2,8 @@ import { useContext } from "react";
 import { InspectorContext } from "./inspector-context";
 
 export const RuleStateCircle = ({ rule }: { rule: { id: string } }) => {
-  const { evaluatedRuleIdsForActor } = useContext(InspectorContext);
-  const applied = evaluatedRuleIdsForActor?.[rule.id];
+  const { evaluatedRuleDetailsForActor } = useContext(InspectorContext);
+  const details = evaluatedRuleDetailsForActor?.[rule.id];
+  const applied = details?.passed;
   return <div className={`circle ${applied}`} />;
 };

--- a/frontend/src/editor/components/sprites/recording-square-status.tsx
+++ b/frontend/src/editor/components/sprites/recording-square-status.tsx
@@ -1,0 +1,46 @@
+import { EvaluatedSquare } from "../../../types";
+import { STAGE_CELL_SIZE } from "../../constants/constants";
+
+interface RecordingSquareStatusProps {
+  squares: EvaluatedSquare[];
+  extentXMin: number;
+  extentYMin: number;
+}
+
+/**
+ * Renders colored overlays on each square in the rule extent to show
+ * whether that square matched during evaluation.
+ */
+export const RecordingSquareStatus = ({
+  squares,
+  extentXMin,
+  extentYMin,
+}: RecordingSquareStatusProps) => {
+  return (
+    <>
+      {squares.map((square) => {
+        const x = extentXMin + square.x;
+        const y = extentYMin + square.y;
+        const color = square.passed
+          ? "rgba(116, 229, 53, 0.35)" // green
+          : "rgba(255, 0, 0, 0.35)"; // red
+
+        return (
+          <div
+            key={`square-status-${square.x}-${square.y}`}
+            style={{
+              position: "absolute",
+              left: x * STAGE_CELL_SIZE,
+              top: y * STAGE_CELL_SIZE,
+              width: STAGE_CELL_SIZE,
+              height: STAGE_CELL_SIZE,
+              backgroundColor: color,
+              pointerEvents: "none",
+              zIndex: 10,
+            }}
+          />
+        );
+      })}
+    </>
+  );
+};

--- a/frontend/src/editor/components/stage/recording/condition-rows.tsx
+++ b/frontend/src/editor/components/stage/recording/condition-rows.tsx
@@ -8,6 +8,7 @@ import {
   Character,
   Characters,
   EditorState,
+  EvaluatedCondition,
   RuleCondition,
   RuleValue,
   Stage,
@@ -24,6 +25,7 @@ interface FreeformConditionRowProps {
   world: WorldMinimal;
   characters: Characters;
   condition: RuleCondition;
+  conditionStatus?: EvaluatedCondition;
   onChange?: (keep: boolean, condition: RuleCondition) => void;
 }
 
@@ -34,11 +36,20 @@ type ImpliedDatatype =
   | { type: "actor" }
   | null;
 
+/** Status circle for condition evaluation */
+const ConditionStatusCircle = ({ status }: { status?: EvaluatedCondition }) => {
+  if (status === undefined) {
+    return <div className="circle" />;
+  }
+  return <div className={`circle ${status.passed}`} />;
+};
+
 export const FreeformConditionRow = ({
   condition,
   actors,
   world,
   characters,
+  conditionStatus,
   onChange,
 }: FreeformConditionRowProps) => {
   const { left, right, comparator } = condition;
@@ -88,6 +99,7 @@ export const FreeformConditionRow = ({
 
   return (
     <li className={`enabled-true tool-supported`} onClick={onToolClick}>
+      <ConditionStatusCircle status={conditionStatus} />
       <FreeformConditionValue
         conditionId={condition.key}
         value={left}

--- a/frontend/src/editor/data-migrations.test.ts
+++ b/frontend/src/editor/data-migrations.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 import { applyValueChanges, applyDataMigrations } from "./data-migrations";
 import { Game } from "../types";
+import { WORLDS } from "./constants/constants";
 
 describe("data-migrations", () => {
   describe("applyValueChanges", () => {
@@ -52,7 +53,7 @@ describe("data-migrations", () => {
         version: 1,
         characters: {},
         world: {
-          id: "MAIN",
+          id: WORLDS.ROOT,
           stages: {},
           globals: {
             click: { id: "click", name: "Clicked Actor", value: "", type: "actor" },
@@ -60,7 +61,7 @@ describe("data-migrations", () => {
             selectedStageId: { id: "selectedStageId", name: "Current Stage", value: "", type: "stage" },
           },
           input: { keys: {}, clicks: {} },
-          evaluatedRuleIds: {},
+          evaluatedRuleDetails: {},
           history: [],
           metadata: { name: "Test", id: 1 },
         },
@@ -74,7 +75,7 @@ describe("data-migrations", () => {
       it("should migrate actor transforms from 'none' to '0'", () => {
         const game = makeMinimalGame({
           world: {
-            id: "MAIN",
+            id: WORLDS.ROOT,
             stages: {
               stage1: {
                 id: "stage1",
@@ -105,7 +106,7 @@ describe("data-migrations", () => {
               selectedStageId: { id: "selectedStageId", name: "Current Stage", value: "", type: "stage" },
             },
             input: { keys: {}, clicks: {} },
-            evaluatedRuleIds: {},
+            evaluatedRuleDetails: {},
             history: [],
             metadata: { name: "Test", id: 1 },
           },
@@ -118,7 +119,7 @@ describe("data-migrations", () => {
       it("should migrate actor transforms from '90deg' to '90'", () => {
         const game = makeMinimalGame({
           world: {
-            id: "MAIN",
+            id: WORLDS.ROOT,
             stages: {
               stage1: {
                 id: "stage1",
@@ -149,7 +150,7 @@ describe("data-migrations", () => {
               selectedStageId: { id: "selectedStageId", name: "Current Stage", value: "", type: "stage" },
             },
             input: { keys: {}, clicks: {} },
-            evaluatedRuleIds: {},
+            evaluatedRuleDetails: {},
             history: [],
             metadata: { name: "Test", id: 1 },
           },
@@ -466,7 +467,7 @@ describe("data-migrations", () => {
       it("should not mutate original game object", () => {
         const game = makeMinimalGame({
           world: {
-            id: "MAIN",
+            id: WORLDS.ROOT,
             stages: {
               stage1: {
                 id: "stage1",
@@ -497,7 +498,7 @@ describe("data-migrations", () => {
               selectedStageId: { id: "selectedStageId", name: "Current Stage", value: "", type: "stage" },
             },
             input: { keys: {}, clicks: {} },
-            evaluatedRuleIds: {},
+            evaluatedRuleDetails: {},
             history: [],
             metadata: { name: "Test", id: 1 },
           },

--- a/frontend/src/editor/reducers/initial-state.ts
+++ b/frontend/src/editor/reducers/initial-state.ts
@@ -36,7 +36,7 @@ const InitialWorld: World = {
     id: 0,
   },
   history: [],
-  evaluatedRuleIds: {},
+  evaluatedRuleDetails: {},
 };
 
 const InitialState: EditorState = {

--- a/frontend/src/editor/styles/editor.scss
+++ b/frontend/src/editor/styles/editor.scss
@@ -87,6 +87,21 @@ html {
   touch-action: pan-x pan-y;
   position: relative;
 
+  .circle {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    border-radius: 12px;
+    background-color: transparent;
+    border: 1px solid rgba(0, 0, 0, 0.2);
+    &.true {
+      background-color: #74e535;
+    }
+    &.false {
+      background-color: red;
+    }
+  }
+
   .loading {
     margin: auto;
     margin-top: 200px;
@@ -847,20 +862,6 @@ html {
       border: 1px solid rgba(255, 255, 25, 0.6);
     }
 
-    .circle {
-      display: inline-block;
-      width: 12px;
-      height: 12px;
-      border-radius: 12px;
-      background-color: transparent;
-      border: 1px solid rgba(0, 0, 0, 0.2);
-      &.true {
-        background-color: #74e535;
-      }
-      &.false {
-        background-color: red;
-      }
-    }
     .icon {
       width: 32px;
       height: 32px;

--- a/frontend/src/editor/utils/frame-accumulator.test.ts
+++ b/frontend/src/editor/utils/frame-accumulator.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { FrameAccumulator, FrameActor } from "./frame-accumulator";
+import { FrameAccumulator } from "./frame-accumulator";
 import { Actor } from "../../types";
 
 describe("FrameAccumulator", () => {

--- a/frontend/src/editor/utils/world-operator.ts
+++ b/frontend/src/editor/utils/world-operator.ts
@@ -358,19 +358,24 @@ export default function WorldOperator(previousWorld: WorldMinimal, characters: C
             continue; // Continue to collect all square results
           }
 
-          // Match stage actors to rule actors. First try with conditions (full match),
-          // then fall back to character-only matching for square status display.
-          // The square status shows "is the right character present" - conditions are
-          // evaluated separately and shown with their own status indicators.
+          // Match stage actors to rule actors using two-phase matching:
+          //
+          // Phase 1 (full match): Use actorsMatch which checks character AND conditions.
+          // This is needed to disambiguate when multiple actors of the same character
+          // exist in a rule (e.g., two zombies with different appearances). Conditions
+          // help determine which stage actor corresponds to which rule actor.
+          //
+          // Phase 2 (character-only fallback): If no full match, try matching by
+          // character only. This provides better UI feedback - squares show green when
+          // the right character is present, even if conditions fail. Conditions are
+          // then evaluated separately and shown with their own status indicators.
+          // For actual rule execution, the full match is still required.
           let squarePassed = true;
           for (const s of stageActorsAtPos) {
-            // First, try to find a full match (character + conditions)
             let match = ruleActorsAtPos.find((r) =>
               actorsMatch(s, r, rule.conditions, stageActorsForReferencedActorId),
             );
 
-            // If no full match, try character-only match for square status
-            // This allows the square to show as "passed" even if conditions fail
             if (!match) {
               match = ruleActorsAtPos.find(
                 (r) =>

--- a/frontend/src/editor/utils/world-operator.ts
+++ b/frontend/src/editor/utils/world-operator.ts
@@ -4,7 +4,10 @@ import {
   ActorTransform,
   Character,
   Characters,
-  EvaluatedRuleIds,
+  EvaluatedCondition,
+  EvaluatedRuleDetails,
+  EvaluatedRuleDetailsMap,
+  EvaluatedSquare,
   FrameInput,
   Globals,
   HistoryItem,
@@ -21,7 +24,6 @@ import {
   RuleTreeFlowLoopItem,
   RuleTreeItem,
   Stage,
-  VariableComparator,
   WorldMinimal,
 } from "../../types";
 import { FrameAccumulator } from "./frame-accumulator";
@@ -45,7 +47,7 @@ export default function WorldOperator(previousWorld: WorldMinimal, characters: C
   let globals: Globals;
   let actors: { [actorId: string]: Actor };
   let input: FrameInput;
-  let evaluatedRuleIds: EvaluatedRuleIds = {};
+  let evaluatedRuleDetails: EvaluatedRuleDetailsMap = {};
   let frameAccumulator: FrameAccumulator;
 
   function wrappedPosition({ x, y }: PositionRelativeToWorld) {
@@ -151,7 +153,7 @@ export default function WorldOperator(previousWorld: WorldMinimal, characters: C
         rules = shuffleArray(rules);
       }
 
-      // perf note: avoid creating empty evaluatedRuleIds entries if no rules are evaluated
+      // perf note: avoid creating empty evaluatedRuleDetails entries if no rules are evaluated
       let iterations = 1;
       if ("behavior" in struct && struct.behavior === FLOW_BEHAVIORS.LOOP) {
         if ("constant" in struct.loopCount && struct.loopCount.constant) {
@@ -166,34 +168,79 @@ export default function WorldOperator(previousWorld: WorldMinimal, characters: C
         }
       }
 
+      let anyApplied = false;
       for (let ii = 0; ii < iterations; ii++) {
         for (const rule of rules) {
-          const applied = tickRule(rule);
-          evaluatedRuleIds[me.id] = evaluatedRuleIds[me.id] || {};
-          evaluatedRuleIds[me.id][rule.id] ||= applied;
-          evaluatedRuleIds[me.id][struct.id] ||= applied;
+          const { applied, details } = tickRule(rule);
+
+          // Store details for this rule
+          evaluatedRuleDetails[me.id] = evaluatedRuleDetails[me.id] || {};
+          if (!evaluatedRuleDetails[me.id][rule.id] || applied) {
+            evaluatedRuleDetails[me.id][rule.id] = details;
+          }
+
+          if (applied) {
+            anyApplied = true;
+          }
           if (applied && !("behavior" in struct && struct.behavior === FLOW_BEHAVIORS.ALL)) {
             break;
           }
         }
       }
 
-      return evaluatedRuleIds[me.id] && evaluatedRuleIds[me.id][struct.id];
+      // Store container-level details (simplified - just tracks if any child passed)
+      if ("id" in struct) {
+        evaluatedRuleDetails[me.id] = evaluatedRuleDetails[me.id] || {};
+        evaluatedRuleDetails[me.id][struct.id] = {
+          passed: anyApplied,
+          conditions: [],
+          squares: [],
+          matchedActors: {},
+        };
+      }
+
+      return anyApplied;
     }
 
-    function tickRule(rule: RuleTreeItem) {
+    function tickRule(rule: RuleTreeItem): { applied: boolean; details: EvaluatedRuleDetails } {
+      const emptyDetails: EvaluatedRuleDetails = {
+        passed: false,
+        conditions: [],
+        squares: [],
+        matchedActors: {},
+      };
+
       if (rule.type === CONTAINER_TYPES.EVENT) {
-        return checkEvent(rule) && tickRulesTree(rule);
+        const eventPassed = checkEvent(rule);
+        if (!eventPassed) {
+          return { applied: false, details: emptyDetails };
+        }
+        const childrenApplied = tickRulesTree(rule);
+        return {
+          applied: childrenApplied,
+          details: { ...emptyDetails, passed: childrenApplied },
+        };
       } else if (rule.type === CONTAINER_TYPES.FLOW) {
-        const checkMet = !rule.check || !!checkRuleScenario(rule.check);
-        return checkMet && tickRulesTree(rule);
+        if (rule.check) {
+          const checkResult = checkRuleScenario(rule.check);
+          if (!checkResult.passed) {
+            return { applied: false, details: checkResult.details };
+          }
+        }
+        const childrenApplied = tickRulesTree(rule);
+        return {
+          applied: childrenApplied,
+          details: { ...emptyDetails, passed: childrenApplied },
+        };
       }
-      const stageActorForId = checkRuleScenario(rule);
-      if (stageActorForId) {
-        applyRule(rule, { stageActorForId, createActorIds: true });
-        return true;
+
+      // Actual rule evaluation
+      const result = checkRuleScenario(rule);
+      if (result.passed && result.stageActorForId) {
+        applyRule(rule, { stageActorForId: result.stageActorForId, createActorIds: true });
+        return { applied: true, details: result.details };
       }
-      return false;
+      return { applied: false, details: result.details };
     }
 
     function checkEvent(trigger: RuleTreeEventItem) {
@@ -209,11 +256,38 @@ export default function WorldOperator(previousWorld: WorldMinimal, characters: C
       throw new Error(`Unknown trigger event: ${trigger.event}`);
     }
 
+    type CheckRuleScenarioResult = {
+      passed: boolean;
+      stageActorForId: { [ruleActorId: string]: Actor } | null;
+      details: EvaluatedRuleDetails;
+    };
+
     function checkRuleScenario(
       rule: Rule | NonNullable<RuleTreeFlowItem["check"]>,
-    ): { [ruleActorId: string]: Actor } | false {
+    ): CheckRuleScenarioResult {
       const ruleActorsUsed = new Set<string>(); // x-y-ruleactorId
       const stageActorsForRuleActorIds: { [ruleActorId: string]: Actor } = {};
+
+      // Initialize details tracking
+      const squares: EvaluatedSquare[] = [];
+      const conditions: EvaluatedCondition[] = [];
+      let failedAt: EvaluatedRuleDetails["failedAt"] | undefined;
+
+      const makeFailResult = (
+        reason: EvaluatedRuleDetails["failedAt"],
+      ): CheckRuleScenarioResult => ({
+        passed: false,
+        stageActorForId: null,
+        details: {
+          passed: false,
+          failedAt: reason,
+          squares,
+          conditions,
+          matchedActors: Object.fromEntries(
+            Object.entries(stageActorsForRuleActorIds).map(([k, v]) => [k, v.id]),
+          ),
+        },
+      });
 
       /** Ben Note: We now allow conditions to specify other actors on the RHS
        * of the equation. This, combined with the fact that you can `ignoreExtraActors`,
@@ -266,7 +340,9 @@ export default function WorldOperator(previousWorld: WorldMinimal, characters: C
           const unwrappedStagePos = pointByAdding(me.position, { x, y });
           const wrappedStagePos = wrappedPosition(unwrappedStagePos);
           if (wrappedStagePos === null) {
-            return false; // offscreen?
+            squares.push({ x, y, passed: false, reason: "offscreen" });
+            if (!failedAt) failedAt = "extent-square";
+            continue; // Continue to collect all square results
           }
           const stageActorsAtPos = Object.values(actors).filter(
             (actor) =>
@@ -279,11 +355,21 @@ export default function WorldOperator(previousWorld: WorldMinimal, characters: C
               !ruleActorsUsed.has(`${actor.id}-${x}-${y}`),
           );
           if (stageActorsAtPos.length !== ruleActorsAtPos.length && !ignoreExtraActors) {
-            return false;
+            squares.push({
+              x,
+              y,
+              passed: false,
+              reason: "actor-count-mismatch",
+              expectedActorCount: ruleActorsAtPos.length,
+              actualActorCount: stageActorsAtPos.length,
+            });
+            if (!failedAt) failedAt = "extent-square";
+            continue; // Continue to collect all square results
           }
 
           // make sure the stage actors match the rule actors, and the
           // additional conditions also match.
+          let squarePassed = true;
           for (const s of stageActorsAtPos) {
             const match = ruleActorsAtPos.find((r) =>
               actorsMatch(s, r, rule.conditions, stageActorsForReferencedActorId),
@@ -293,16 +379,35 @@ export default function WorldOperator(previousWorld: WorldMinimal, characters: C
               stageActorsForRuleActorIds[match.id] = s;
               ruleActorsUsed.add(`${match.id}-${wrappedStagePos.x}-${wrappedStagePos.y}`);
             } else if (!ignoreExtraActors) {
-              return false;
+              squarePassed = false;
             }
           }
+
+          if (squarePassed) {
+            squares.push({ x, y, passed: true, reason: "ok" });
+          } else {
+            squares.push({
+              x,
+              y,
+              passed: false,
+              reason: "actor-match-failed",
+              expectedActorCount: ruleActorsAtPos.length,
+              actualActorCount: stageActorsAtPos.length,
+            });
+            if (!failedAt) failedAt = "extent-square";
+          }
         }
+      }
+
+      // If we already failed at extent-square level, return early with all collected data
+      if (failedAt === "extent-square") {
+        return makeFailResult("extent-square");
       }
 
       // If we didn't find all the actors required for conditions + actions, we failed
       for (const ruleActorId of getActionAndConditionActorIds(rule)) {
         if (!stageActorsForRuleActorIds[ruleActorId]) {
-          return false;
+          return makeFailResult("missing-required-actor");
         }
       }
 
@@ -313,7 +418,7 @@ export default function WorldOperator(previousWorld: WorldMinimal, characters: C
           if ("offset" in action && action.offset) {
             const stagePos = wrappedPosition(pointByAdding(me.position, action.offset));
             if (stagePos === null) {
-              return false;
+              return makeFailResult("action-offset-invalid");
             }
           }
         }
@@ -322,7 +427,11 @@ export default function WorldOperator(previousWorld: WorldMinimal, characters: C
       // Re-check conditions - We check the conditions that involve actorIds when
       // matching the rule actors to the stage actors, but we haven't checked
       // global-to-global or global-to-variable style rules yet.
+      // Now we track all condition results for detailed feedback.
+      let allConditionsPassed = true;
       for (const condition of rule.conditions) {
+        if (!condition.enabled) continue;
+
         const left = resolveRuleValue(
           condition.left,
           globals,
@@ -337,12 +446,34 @@ export default function WorldOperator(previousWorld: WorldMinimal, characters: C
           stageActorsForRuleActorIds,
           condition.comparator,
         );
-        if (!comparatorMatches(condition.comparator, left, right)) {
-          return false;
+        const passed = comparatorMatches(condition.comparator, left, right);
+        conditions.push({
+          conditionKey: condition.key,
+          passed,
+          leftValue: left,
+          rightValue: right,
+        });
+        if (!passed) {
+          allConditionsPassed = false;
         }
       }
 
-      return stageActorsForRuleActorIds;
+      if (!allConditionsPassed) {
+        return makeFailResult("condition-failed");
+      }
+
+      return {
+        passed: true,
+        stageActorForId: stageActorsForRuleActorIds,
+        details: {
+          passed: true,
+          squares,
+          conditions,
+          matchedActors: Object.fromEntries(
+            Object.entries(stageActorsForRuleActorIds).map(([k, v]) => [k, v.id]),
+          ),
+        },
+      };
     }
 
     function getActionAndConditionActorIds(rule: Rule | NonNullable<RuleTreeFlowItem["check"]>) {
@@ -579,7 +710,7 @@ export default function WorldOperator(previousWorld: WorldMinimal, characters: C
     const historyItem: HistoryItem = {
       input: previousWorld.input,
       globals: previousWorld.globals,
-      evaluatedRuleIds: previousWorld.evaluatedRuleIds,
+      evaluatedRuleDetails: previousWorld.evaluatedRuleDetails,
       stages: {
         [stage.id]: {
           actors: stage.actors,
@@ -594,11 +725,11 @@ export default function WorldOperator(previousWorld: WorldMinimal, characters: C
 
     actors = deepClone(stage.actors);
     frameAccumulator = new FrameAccumulator(stage.actors);
-    evaluatedRuleIds = {};
+    evaluatedRuleDetails = {};
 
     Object.values(actors).forEach((actor) => ActorOperator(actor).tickAllRules());
-    const evaluatedSomeRule = Object.values(evaluatedRuleIds).some((actorRuleIds) =>
-      Object.values(actorRuleIds).includes(true),
+    const evaluatedSomeRule = Object.values(evaluatedRuleDetails).some((actorRuleDetails) =>
+      Object.values(actorRuleDetails).some((details) => details.passed),
     );
 
     return u(
@@ -613,7 +744,7 @@ export default function WorldOperator(previousWorld: WorldMinimal, characters: C
           },
         },
         globals: u.constant(globals),
-        evaluatedRuleIds: u.constant(evaluatedRuleIds),
+        evaluatedRuleDetails: u.constant(evaluatedRuleDetails),
         evaluatedTickFrames: frameAccumulator.getFrames(),
         history: (values: HistoryItem[]) =>
           evaluatedSomeRule ? [...values.slice(values.length - 20), historyItem] : values,
@@ -643,7 +774,7 @@ export default function WorldOperator(previousWorld: WorldMinimal, characters: C
             actors: u.constant(historyItem.stages[historyStageKey].actors),
           },
         },
-        evaluatedRuleIds: u.constant(historyItem.evaluatedRuleIds),
+        evaluatedRuleDetails: u.constant(historyItem.evaluatedRuleDetails),
         evaluatedTickFrames: [],
         history: history.slice(0, history.length - 1),
       },

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -244,9 +244,51 @@ export type Character = {
   >;
 };
 
-export type EvaluatedRuleIds = {
+/** Detailed evaluation result for a single condition */
+export type EvaluatedCondition = {
+  conditionKey: string;
+  passed: boolean;
+  leftValue?: string | null;
+  rightValue?: string | null;
+};
+
+/** Detailed evaluation result for a single extent square */
+export type EvaluatedSquare = {
+  x: number;
+  y: number;
+  passed: boolean;
+  reason?:
+    | "offscreen" // Position is offscreen on non-wrapping stage
+    | "actor-count-mismatch" // Different number of actors than expected
+    | "actor-match-failed" // Actor exists but doesn't match rule actor
+    | "ok"; // Square passed
+  expectedActorCount?: number;
+  actualActorCount?: number;
+};
+
+/** Detailed evaluation result for a rule */
+export type EvaluatedRuleDetails = {
+  passed: boolean;
+
+  // Which stage of checking caused failure (for quick diagnosis)
+  failedAt?:
+    | "extent-square" // A square in the extent didn't match
+    | "missing-required-actor" // A required actor wasn't found
+    | "action-offset-invalid" // An action would go offscreen
+    | "condition-failed"; // A condition check failed
+
+  // Detailed breakdown
+  conditions: EvaluatedCondition[];
+  squares: EvaluatedSquare[];
+
+  // Which actors were successfully matched (ruleActorId -> stageActorId)
+  matchedActors: { [ruleActorId: string]: string };
+};
+
+/** Granular evaluation data per actor per rule */
+export type EvaluatedRuleDetailsMap = {
   [actorId: string]: {
-    [ruleTreeItemId: string]: boolean;
+    [ruleId: string]: EvaluatedRuleDetails;
   };
 };
 
@@ -285,7 +327,7 @@ export type Globals = {
 export type HistoryItem = {
   input: FrameInput;
   globals: Globals;
-  evaluatedRuleIds: EvaluatedRuleIds;
+  evaluatedRuleDetails: EvaluatedRuleDetailsMap;
   stages: { [stageId: string]: Pick<Stage, "actors"> };
 };
 
@@ -294,7 +336,7 @@ export type WorldMinimal = {
   stages: { [stageId: string]: Stage };
   globals: Globals;
   input: FrameInput;
-  evaluatedRuleIds: EvaluatedRuleIds;
+  evaluatedRuleDetails: EvaluatedRuleDetailsMap;
   evaluatedTickFrames?: Frame[];
 };
 


### PR DESCRIPTION
This plan outlines how to enhance the rule evaluation system to track
not just whether a rule matched, but which specific conditions and
extent squares caused failures. This will enable more detailed UI
indicators at the condition and square level instead of just rule-level.