### PR TITLE
Add minus buttons to appearance editor canvas

### DIFF
--- a/frontend/src/editor/components/modal-explore-characters/container.jsx
+++ b/frontend/src/editor/components/modal-explore-characters/container.jsx
@@ -106,16 +106,16 @@ class Container extends React.Component {
         <div className="modal-header" style={{ display: "flex" }}>
           <h4 style={{ flex: 1 }}>Explore Characters</h4>
         </div>
-        <ModalBody>
-          {this.state.characters ? (
-            <CharacterBrowser
-              characters={this.state.characters}
-              onAddCharacter={this._onAddCharacter}
-            />
-          ) : (
+        {this.state.characters ? (
+          <CharacterBrowser
+            characters={this.state.characters}
+            onAddCharacter={this._onAddCharacter}
+          />
+        ) : (
+          <ModalBody>
             <div>Loading...</div>
-          )}
-        </ModalBody>
+          </ModalBody>
+        )}
         <ModalFooter>
           <Button onClick={() => this.props.dispatch(dismissModal())}>Done</Button>
         </ModalFooter>

--- a/frontend/src/editor/components/modal-paint/container.jsx
+++ b/frontend/src/editor/components/modal-paint/container.jsx
@@ -778,6 +778,7 @@ class Container extends React.Component {
                 <Button
                   className="canvas-arrow"
                   size="sm"
+                  disabled={imageData.height <= 40}
                   onClick={() => this._onCanvasShrink(0, -1, 0, -1)}
                 >
                   −
@@ -793,6 +794,7 @@ class Container extends React.Component {
                   <Button
                     className="canvas-arrow"
                     size="sm"
+                    disabled={imageData.width <= 40}
                     onClick={() => this._onCanvasShrink(-1, 0, -1, 0)}
                   >
                     −
@@ -826,6 +828,7 @@ class Container extends React.Component {
                       <Button
                         size="sm"
                         className="canvas-arrow"
+                        disabled={imageData.width <= 40}
                         onClick={() => this._onCanvasShrink(-1, 0, 0, 0)}
                       >
                         −
@@ -855,6 +858,7 @@ class Container extends React.Component {
                 <Button
                   className="canvas-arrow"
                   size="sm"
+                  disabled={imageData.height <= 40}
                   onClick={() => this._onCanvasShrink(0, -1, 0, 0)}
                 >
                   −

--- a/frontend/src/editor/components/modal-paint/container.jsx
+++ b/frontend/src/editor/components/modal-paint/container.jsx
@@ -609,6 +609,18 @@ class Container extends React.Component {
     );
   };
 
+  _onCanvasShrink = (dSquaresX, dSquaresY, offsetX, offsetY) => {
+    const newWidth = this.state.imageData.width + 40 * dSquaresX;
+    const newHeight = this.state.imageData.height + 40 * dSquaresY;
+
+    // Prevent shrinking below 1 square (40x40 pixels)
+    if (newWidth < 40 || newHeight < 40) {
+      return;
+    }
+
+    this._onCanvasUpdateSize(dSquaresX, dSquaresY, offsetX, offsetY);
+  };
+
   render() {
     const { imageData, tool, toolSize, color, undoStack, redoStack } = this.state;
 
@@ -761,6 +773,13 @@ class Container extends React.Component {
                 >
                   +
                 </Button>
+                <Button
+                  className="canvas-arrow"
+                  size="sm"
+                  onClick={() => this._onCanvasShrink(0, -1, 0, -1)}
+                >
+                  −
+                </Button>
                 <div className="canvas-arrows-flex" style={{ flexDirection: "row" }}>
                   <Button
                     className="canvas-arrow"
@@ -768,6 +787,13 @@ class Container extends React.Component {
                     onClick={() => this._onCanvasUpdateSize(1, 0, 1, 0)}
                   >
                     +
+                  </Button>
+                  <Button
+                    className="canvas-arrow"
+                    size="sm"
+                    onClick={() => this._onCanvasShrink(-1, 0, -1, 0)}
+                  >
+                    −
                   </Button>
                   <div style={{ position: "relative" }}>
                     <PixelCanvas
@@ -790,17 +816,26 @@ class Container extends React.Component {
                       height: "100%",
                       display: "grid",
                       gap: 20,
-                      gridTemplateRows: "1fr 22px 1fr",
+                      gridTemplateRows: "1fr auto 1fr",
                     }}
                   >
                     <span />
-                    <Button
-                      size="sm"
-                      className="canvas-arrow"
-                      onClick={() => this._onCanvasUpdateSize(1, 0, 0, 0)}
-                    >
-                      +
-                    </Button>
+                    <div className="canvas-arrows-flex" style={{ flexDirection: "row" }}>
+                      <Button
+                        size="sm"
+                        className="canvas-arrow"
+                        onClick={() => this._onCanvasShrink(-1, 0, 0, 0)}
+                      >
+                        −
+                      </Button>
+                      <Button
+                        size="sm"
+                        className="canvas-arrow"
+                        onClick={() => this._onCanvasUpdateSize(1, 0, 0, 0)}
+                      >
+                        +
+                      </Button>
+                    </div>
                     <div>
                       <input
                         type="range"
@@ -815,6 +850,13 @@ class Container extends React.Component {
                     </div>
                   </div>
                 </div>
+                <Button
+                  className="canvas-arrow"
+                  size="sm"
+                  onClick={() => this._onCanvasShrink(0, -1, 0, 0)}
+                >
+                  −
+                </Button>
                 <Button
                   className="canvas-arrow"
                   size="sm"

--- a/frontend/src/editor/components/modal-paint/container.jsx
+++ b/frontend/src/editor/components/modal-paint/container.jsx
@@ -475,7 +475,9 @@ class Container extends React.Component {
 
     this.setState({ isGeneratingSprite: true });
     try {
-      const data = await makeRequest(`/generate-sprite?prompt=${encodeURIComponent(prompt)}&width=${canvasWidth}&height=${canvasHeight}`);
+      const data = await makeRequest(
+        `/generate-sprite?prompt=${encodeURIComponent(prompt)}&width=${canvasWidth}&height=${canvasHeight}`,
+      );
       if (data.imageUrl) {
         console.log("data.imageUrl", data.imageUrl);
         // Use fill:true to ensure the AI image fills the entire canvas
@@ -635,7 +637,7 @@ class Container extends React.Component {
             onChange={this._onChooseFile}
             onFocus={(event) => event.target.parentNode.focus()}
           />
-          <div className="modal-header" style={{ display: "flex" }}>
+          <div className="modal-header" style={{ display: "flex", alignItems: "center" }}>
             <h4 style={{ flex: 1 }}>Edit Appearance</h4>
             <Button
               title="Undo"
@@ -841,7 +843,7 @@ class Container extends React.Component {
                         type="range"
                         min={1}
                         max={11}
-                        style={{ writingMode: "vertical-rl", marginLeft: 3 }}
+                        style={{ writingMode: "vertical-rl", marginLeft: 14 }}
                         value={this.state.pixelSize}
                         onChange={(e) =>
                           this.setState({ ...this.state, pixelSize: Number(e.currentTarget.value) })
@@ -864,37 +866,38 @@ class Container extends React.Component {
                 >
                   +
                 </Button>
-                <div
-                  className="ai-sprite-generator"
-                  style={{ display: "flex", alignItems: "center", gap: 8 }}
-                >
-                  <input
-                    type="text"
-                    style={{ flex: 1 }}
-                    placeholder="Describe your sprite..."
-                    value={this.state.spriteDescription || ""}
-                    onChange={(e) => this.setState({ spriteDescription: e.target.value })}
-                  />
-                  <Button
-                    size="sm"
-                    onClick={this._onGenerateSprite}
-                    disabled={this.state.isGeneratingSprite}
-                  >
-                    {this.state.isGeneratingSprite ? (
-                      <span>
-                        <i className="fa fa-spinner fa-spin" /> Drawing...
-                      </span>
-                    ) : (
-                      <span>
-                        <i className="fa fa-magic" /> Draw with AI
-                      </span>
-                    )}
-                  </Button>
-                </div>
               </div>
             </div>
           </ModalBody>
           <ModalFooter>
+            <div
+              className="ai-sprite-generator"
+              style={{ display: "flex", alignItems: "center", gap: 8 }}
+            >
+              <input
+                type="text"
+                style={{ flex: 1 }}
+                placeholder="Describe your sprite..."
+                value={this.state.spriteDescription || ""}
+                onChange={(e) => this.setState({ spriteDescription: e.target.value })}
+              />
+              <Button
+                size="sm"
+                onClick={this._onGenerateSprite}
+                disabled={this.state.isGeneratingSprite}
+              >
+                {this.state.isGeneratingSprite ? (
+                  <span>
+                    <i className="fa fa-spinner fa-spin" /> Drawing...
+                  </span>
+                ) : (
+                  <span>
+                    <i className="fa fa-magic" /> Draw with AI
+                  </span>
+                )}
+              </Button>
+            </div>
+            <div style={{ flex: 1 }} />
             <Button key="cancel" onClick={this._onClose}>
               Close without Saving
             </Button>{" "}

--- a/frontend/src/editor/components/modal-paint/container.jsx
+++ b/frontend/src/editor/components/modal-paint/container.jsx
@@ -778,7 +778,7 @@ class Container extends React.Component {
                 <Button
                   className="canvas-arrow"
                   size="sm"
-                  disabled={imageData.height <= 40}
+                  disabled={imageData && imageData.height <= 40}
                   onClick={() => this._onCanvasShrink(0, -1, 0, -1)}
                 >
                   −
@@ -794,7 +794,7 @@ class Container extends React.Component {
                   <Button
                     className="canvas-arrow"
                     size="sm"
-                    disabled={imageData.width <= 40}
+                    disabled={imageData && imageData.width <= 40}
                     onClick={() => this._onCanvasShrink(-1, 0, -1, 0)}
                   >
                     −
@@ -828,7 +828,7 @@ class Container extends React.Component {
                       <Button
                         size="sm"
                         className="canvas-arrow"
-                        disabled={imageData.width <= 40}
+                        disabled={imageData && imageData.width <= 40}
                         onClick={() => this._onCanvasShrink(-1, 0, 0, 0)}
                       >
                         −
@@ -858,7 +858,7 @@ class Container extends React.Component {
                 <Button
                   className="canvas-arrow"
                   size="sm"
-                  disabled={imageData.height <= 40}
+                  disabled={imageData && imageData.height <= 40}
                   onClick={() => this._onCanvasShrink(0, -1, 0, 0)}
                 >
                   −

--- a/frontend/src/editor/styles/editor.scss
+++ b/frontend/src/editor/styles/editor.scss
@@ -622,8 +622,8 @@ html {
 
 .modal-dialog.paint {
   user-select: none;
-  min-width: 660px;
-  max-width: 660px;
+  min-width: 720px;
+  max-width: 720px;
   canvas {
     cursor: crosshair;
   }
@@ -816,7 +816,9 @@ html {
     border: 2px solid transparent;
     border-radius: 4px;
     background: #f5f5f5;
-    transition: border-color 0.1s, background-color 0.1s;
+    transition:
+      border-color 0.1s,
+      background-color 0.1s;
 
     &:hover {
       border-color: #007bff;
@@ -1241,6 +1243,7 @@ button.btn.selected:active {
 
 .character-cards {
   max-height: 500px;
+  padding-left: 8px;
   overflow-y: scroll;
   display: flex;
   flex-direction: row;

--- a/frontend/src/styles/styles.scss
+++ b/frontend/src/styles/styles.scss
@@ -9,6 +9,13 @@ body {
   margin: 0;
   padding: 0;
 }
+.modal-header {
+  padding-top: 16px;
+  padding-bottom: 12px;
+  h4 {
+    margin-bottom: 0;
+  }
+}
 
 .navbar-nav .nav-item + .nav-item {
   margin-left: 1.4rem;


### PR DESCRIPTION
Add "-" buttons alongside the existing "+" buttons in the appearance editor canvas controls. The "-" buttons are positioned closer to the canvas than the "+" buttons to visually imply contraction vs expansion.

- Add _onCanvasShrink method with validation to prevent shrinking below 1 square (40x40 pixels)
- Add "-" buttons at all four positions (top, left, right, bottom)
- Reuse existing canvas-arrow styling for consistent appearance