### PR TITLE
Fix appearance editor canvas pixel conversion bugs

### DIFF
--- a/frontend/src/editor/components/modal-paint/container.tsx
+++ b/frontend/src/editor/components/modal-paint/container.tsx
@@ -429,6 +429,7 @@ const PaintContainer: React.FC = () => {
               placeholder="Describe your sprite..."
               value={state.spriteDescription || ""}
               onChange={(e) => model.setSpriteDescription(e.target.value)}
+              disabled={state.isGeneratingSprite}
             />
             <Button size="sm" onClick={() => model.generateSprite()} disabled={state.isGeneratingSprite}>
               {state.isGeneratingSprite ? (

--- a/frontend/src/editor/components/modal-paint/pixel-canvas.tsx
+++ b/frontend/src/editor/components/modal-paint/pixel-canvas.tsx
@@ -67,8 +67,8 @@ const PixelCanvas: React.FC<PixelCanvasProps> = ({
       }
       const { top, left } = canvasRef.current.getBoundingClientRect();
       return {
-        x: Math.round((clientX - left + pixelSize / 2) / pixelSize),
-        y: Math.round((clientY - top + pixelSize / 2) / pixelSize),
+        x: Math.floor((clientX - left) / pixelSize),
+        y: Math.floor((clientY - top) / pixelSize),
       };
     },
     [pixelSize]


### PR DESCRIPTION
- Fix canvas click-to-pixel conversion being off by ~10px by using Math.floor instead of Math.round with an incorrect offset
- Disable AI sprite description input while generation is in progress