### PR TITLE
Hide condition status circles for unevaluated rules

### DIFF
--- a/frontend/src/editor/components/inspector/rule-state-circle.tsx
+++ b/frontend/src/editor/components/inspector/rule-state-circle.tsx
@@ -4,6 +4,8 @@ import { InspectorContext } from "./inspector-context";
 export const RuleStateCircle = ({ rule }: { rule: { id: string } }) => {
   const { evaluatedRuleDetailsForActor } = useContext(InspectorContext);
   const details = evaluatedRuleDetailsForActor?.[rule.id];
-  const applied = details?.passed;
-  return <div className={`circle ${applied}`} />;
+  if (details === undefined) {
+    return null;
+  }
+  return <div className={`circle ${details.passed}`} />;
 };

--- a/frontend/src/editor/components/stage/recording/condition-rows.tsx
+++ b/frontend/src/editor/components/stage/recording/condition-rows.tsx
@@ -36,10 +36,10 @@ type ImpliedDatatype =
   | { type: "actor" }
   | null;
 
-/** Status circle for condition evaluation */
+/** Status circle for condition evaluation - hidden when not evaluated */
 const ConditionStatusCircle = ({ status }: { status?: EvaluatedCondition }) => {
   if (status === undefined) {
-    return <div className="circle" />;
+    return null;
   }
   return <div className={`circle ${status.passed}`} />;
 };


### PR DESCRIPTION
Instead of showing an empty default circle when evaluation data is missing, the condition status circles are now hidden entirely. This makes it clearer when a rule is new and hasn't been evaluated yet.