### PR TITLE
Reduce useSelector type parameter boilerplate

### DIFF
--- a/frontend/src/components/app.tsx
+++ b/frontend/src/components/app.tsx
@@ -1,15 +1,15 @@
 import * as Sentry from "@sentry/react";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import { Link, Outlet, useLocation } from "react-router-dom";
 import Button from "reactstrap/lib/Button";
 
 import { logout } from "../actions/main-actions";
-import { MainState } from "../reducers/initial-state";
+import { useAppSelector } from "../hooks/redux";
 
 const App = () => {
   const location = useLocation();
-  const me = useSelector<MainState, MainState["me"]>((state) => state.me);
-  const network = useSelector<MainState, MainState["network"]>((state) => state.network);
+  const me = useAppSelector((state) => state.me);
+  const network = useAppSelector((state) => state.network);
   const dispatch = useDispatch();
 
   const _renderNav = () => {

--- a/frontend/src/components/dashboard-page.tsx
+++ b/frontend/src/components/dashboard-page.tsx
@@ -1,18 +1,17 @@
 import React, { useEffect } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import Button from "reactstrap/lib/Button";
 import Col from "reactstrap/lib/Col";
 import Container from "reactstrap/lib/Container";
 import Row from "reactstrap/lib/Row";
 
 import { createWorld, deleteWorld, fetchWorldsForUser } from "../actions/main-actions";
-import { MainState } from "../reducers/initial-state";
-import { Game } from "../types";
+import { useAppSelector } from "../hooks/redux";
 import WorldList from "./common/world-list";
 
 const DashboardPage: React.FC = () => {
   const dispatch = useDispatch();
-  const worlds = useSelector<MainState, Game[] | undefined>((state) => {
+  const worlds = useAppSelector((state) => {
     if (!state.worlds || !state.me) return undefined;
     return Object.values(state.worlds)
       .filter((w) => w.userId === state.me?.id)

--- a/frontend/src/components/editor-page.tsx
+++ b/frontend/src/components/editor-page.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useEffect, useRef, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 
 import { createWorld, User } from "../actions/main-actions";
 import RootEditor from "../editor/root-editor";
@@ -11,7 +11,7 @@ import { usePageTitle } from "../hooks/usePageTitle";
 
 import { useParams } from "react-router";
 import { applyDataMigrations } from "../editor/data-migrations";
-import { MainState } from "../reducers/initial-state";
+import { useAppSelector } from "../hooks/redux";
 import { Game } from "../types";
 import PageMessage from "./common/page-message";
 import { EditorContext } from "./editor-context";
@@ -77,7 +77,7 @@ const LocalStorageAdapter = {
 // };
 
 const EditorPage = () => {
-  const me = useSelector<MainState, User>((s) => s.me!);
+  const me = useAppSelector((s) => s.me!);
   const dispatch = useDispatch();
 
   const worldId = useParams().worldId!;

--- a/frontend/src/components/home-page.tsx
+++ b/frontend/src/components/home-page.tsx
@@ -1,17 +1,17 @@
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import { Link } from "react-router-dom";
 import Button from "reactstrap/lib/Button";
 
 import { useState } from "react";
 import { Modal, ModalBody } from "reactstrap";
 import { createWorld } from "../actions/main-actions";
-import { MainState } from "../reducers/initial-state";
+import { useAppSelector } from "../hooks/redux";
 
 const HomePage = () => {
   const dispatch = useDispatch();
   const [showingNew, setShowingNew] = useState(false);
 
-  const me = useSelector<MainState, MainState["me"]>((root) => root.me);
+  const me = useAppSelector((root) => root.me);
 
   return (
     <div>

--- a/frontend/src/components/join-page.tsx
+++ b/frontend/src/components/join-page.tsx
@@ -1,5 +1,5 @@
 import React, { useRef } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import Button from "reactstrap/lib/Button";
 import Col from "reactstrap/lib/Col";
 import Container from "reactstrap/lib/Container";
@@ -7,7 +7,7 @@ import Row from "reactstrap/lib/Row";
 
 import { useLocation } from "react-router";
 import { register } from "../actions/main-actions";
-import { MainState } from "../reducers/initial-state";
+import { useAppSelector } from "../hooks/redux";
 
 interface NetworkError extends Error {
   statusCode?: number;
@@ -19,7 +19,7 @@ const JoinPage: React.FC = () => {
   const passRef = useRef<HTMLInputElement>(null);
   const emailRef = useRef<HTMLInputElement>(null);
   const dispatch = useDispatch();
-  const networkError = useSelector<MainState, Error | null>((state) => state.network.error);
+  const networkError = useAppSelector((state) => state.network.error);
 
   const search = new URLSearchParams(location.search);
 

--- a/frontend/src/components/login-page.tsx
+++ b/frontend/src/components/login-page.tsx
@@ -1,5 +1,5 @@
 import React, { useRef } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import { Link, useLocation } from "react-router-dom";
 import Button from "reactstrap/lib/Button";
 import Col from "reactstrap/lib/Col";
@@ -7,14 +7,14 @@ import Container from "reactstrap/lib/Container";
 import Row from "reactstrap/lib/Row";
 
 import { login } from "../actions/main-actions";
-import { MainState } from "../reducers/initial-state";
+import { useAppSelector } from "../hooks/redux";
 
 const LoginPage: React.FC = () => {
   const usernameRef = useRef<HTMLInputElement>(null);
   const passRef = useRef<HTMLInputElement>(null);
   const location = useLocation();
   const dispatch = useDispatch();
-  const networkError = useSelector<MainState, Error | null>((state) => state.network.error);
+  const networkError = useAppSelector((state) => state.network.error);
 
   const locationState = location.state as { redirectTo?: string } | null;
 

--- a/frontend/src/components/play-page.tsx
+++ b/frontend/src/components/play-page.tsx
@@ -1,26 +1,23 @@
 import React, { useEffect } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import { Link, useParams } from "react-router-dom";
 import Button from "reactstrap/lib/Button";
 import Col from "reactstrap/lib/Col";
 import Container from "reactstrap/lib/Container";
 import Row from "reactstrap/lib/Row";
 
-import { createWorld, fetchWorld, User } from "../actions/main-actions";
+import { createWorld, fetchWorld } from "../actions/main-actions";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { RootPlayer } from "../editor/root-player";
 import PageMessage from "./common/page-message";
-import { MainState } from "../reducers/initial-state";
-import { Game } from "../types";
+import { useAppSelector } from "../hooks/redux";
 
 const PlayPage: React.FC = () => {
   const { worldId } = useParams<{ worldId: string }>();
   const dispatch = useDispatch();
 
-  const me = useSelector<MainState, User | null>((state) => state.me);
-  const worlds = useSelector<MainState, { [worldId: string]: Game } | null>(
-    (state) => state.worlds,
-  );
+  const me = useAppSelector((state) => state.me);
+  const worlds = useAppSelector((state) => state.worlds);
 
   const world = worlds && worldId ? worlds[worldId] : null;
 

--- a/frontend/src/components/profile-page.tsx
+++ b/frontend/src/components/profile-page.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import Col from "reactstrap/lib/Col";
 import Container from "reactstrap/lib/Container";
 import Row from "reactstrap/lib/Row";
@@ -13,8 +13,7 @@ import {
 
 import { useParams } from "react-router";
 import { usePageTitle } from "../hooks/usePageTitle";
-import { MainState } from "../reducers/initial-state";
-import { Game } from "../types";
+import { useAppSelector } from "../hooks/redux";
 import WorldList from "./common/world-list";
 
 const LOADING_PROFILE: Profile = {
@@ -27,10 +26,7 @@ const ProfilePage = () => {
 
   const { username } = useParams();
 
-  const { me, profile, worlds } = useSelector<
-    MainState,
-    { me: MainState["me"]; profile: Profile; worlds: Game[] | null }
-  >((state) => {
+  const { me, profile, worlds } = useAppSelector((state) => {
     const profile = state.profiles[username!];
     return {
       me: state.me,

--- a/frontend/src/editor/components/cursor-support.tsx
+++ b/frontend/src/editor/components/cursor-support.tsx
@@ -1,6 +1,5 @@
 import { useLayoutEffect } from "react";
-import { useSelector } from "react-redux";
-import { Characters, EditorState, Stage } from "../../types";
+import { useEditorSelector } from "../../hooks/redux";
 import { TOOLS } from "../constants/constants";
 import { defaultAppearanceId } from "../utils/character-helpers";
 import { getCurrentStage } from "../utils/selectors";
@@ -64,11 +63,9 @@ function updateCursor() {
 }
 
 export const StampCursorSupport = () => {
-  const stage = useSelector<EditorState, Stage | null>((state) => getCurrentStage(state));
-  const characters = useSelector<EditorState, Characters>((state) => state.characters);
-  const { selectedToolId, stampToolItem } = useSelector<EditorState, EditorState["ui"]>(
-    (state) => state.ui,
-  );
+  const stage = useEditorSelector((state) => getCurrentStage(state));
+  const characters = useEditorSelector((state) => state.characters);
+  const { selectedToolId, stampToolItem } = useEditorSelector((state) => state.ui);
 
   useLayoutEffect(() => {
     cursorEl.style.transformOrigin = "0%,0%";

--- a/frontend/src/editor/components/inspector/container-pane-rules.tsx
+++ b/frontend/src/editor/components/inspector/container-pane-rules.tsx
@@ -1,14 +1,8 @@
 import React, { useEffect, useRef } from "react";
 
-import { useDispatch, useSelector } from "react-redux";
-import {
-  Character,
-  EditorState,
-  Rule,
-  RuleTreeFlowItemCheck,
-  RuleTreeItem,
-  UIState,
-} from "../../../types";
+import { useDispatch } from "react-redux";
+import { Character, Rule, RuleTreeFlowItemCheck, RuleTreeItem } from "../../../types";
+import { useEditorSelector } from "../../../hooks/redux";
 import { upsertCharacter } from "../../actions/characters-actions";
 import { editRuleRecording } from "../../actions/recording-actions";
 import { selectToolId } from "../../actions/ui-actions";
@@ -27,7 +21,7 @@ export const RuleActionsContext = React.createContext<{
 
 export const ContainerPaneRules = ({ character }: { character: Character | null }) => {
   const dispatch = useDispatch();
-  const { selectedToolId, stampToolItem } = useSelector<EditorState, UIState>((state) => state.ui);
+  const { selectedToolId, stampToolItem } = useEditorSelector((state) => state.ui);
   const _scrollContainerEl = useRef<HTMLDivElement>(null);
   const _scrollId = useRef<number>(0);
 

--- a/frontend/src/editor/components/inspector/container-pane-variables.tsx
+++ b/frontend/src/editor/components/inspector/container-pane-variables.tsx
@@ -5,18 +5,11 @@ import DropdownItem from "reactstrap/lib/DropdownItem";
 import DropdownMenu from "reactstrap/lib/DropdownMenu";
 import DropdownToggle from "reactstrap/lib/DropdownToggle";
 
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import { Button } from "reactstrap";
 import { DeepPartial } from "redux";
-import {
-  Actor,
-  ActorSelection,
-  ActorTransform,
-  Character,
-  EditorState,
-  Global,
-  WorldMinimal,
-} from "../../../types";
+import { Actor, ActorTransform, Character, Global, WorldMinimal } from "../../../types";
+import { useEditorSelector } from "../../../hooks/redux";
 import { deleteCharacterVariable, upsertCharacter } from "../../actions/characters-actions";
 import { changeActors } from "../../actions/stage-actions";
 import { selectToolId } from "../../actions/ui-actions";
@@ -157,10 +150,8 @@ export const ContainerPaneVariables = ({
   world: WorldMinimal;
 }) => {
   const dispatch = useDispatch();
-  const selectedToolId = useSelector<EditorState, TOOLS>((state) => state.ui.selectedToolId);
-  const selectedActors = useSelector<EditorState, ActorSelection | null>(
-    (state) => state.ui.selectedActors,
-  );
+  const selectedToolId = useEditorSelector((state) => state.ui.selectedToolId);
+  const selectedActors = useEditorSelector((state) => state.ui.selectedActors);
 
   // Chararacter and actor variables
 

--- a/frontend/src/editor/components/inspector/container.tsx
+++ b/frontend/src/editor/components/inspector/container.tsx
@@ -1,6 +1,5 @@
 import classNames from "classnames";
 import { useEffect, useState } from "react";
-import { useSelector } from "react-redux";
 import Nav from "reactstrap/lib/Nav";
 import NavItem from "reactstrap/lib/NavItem";
 import NavLink from "reactstrap/lib/NavLink";
@@ -10,14 +9,12 @@ import AddVariableButton from "./add-variable-button";
 import { ContainerPaneRules } from "./container-pane-rules";
 import { ContainerPaneVariables } from "./container-pane-variables";
 
-import { EditorState } from "../../../types";
+import { useEditorSelector } from "../../../hooks/redux";
 import { getCurrentStageForWorld } from "../../utils/selectors";
 import { InspectorContext } from "./inspector-context";
 
 export const InspectorContainer = () => {
-  const { ui, recording, world, characters } = useSelector<EditorState, EditorState>(
-    (state) => state,
-  );
+  const { ui, recording, world, characters } = useEditorSelector((state) => state);
 
   const isRecording = !!recording.characterId;
   const [activeTab, setActiveTab] = useState<"rules" | "variables">(

--- a/frontend/src/editor/components/inspector/rule-list.tsx
+++ b/frontend/src/editor/components/inspector/rule-list.tsx
@@ -4,8 +4,9 @@ import { ContentEventGroup } from "./content-event-group";
 import { ContentFlowGroup } from "./content-flow-group";
 import { ContentRule } from "./content-rule";
 
-import { useDispatch, useSelector } from "react-redux";
-import { Character, EditorState, RuleTreeItem, UIState } from "../../../types";
+import { useDispatch } from "react-redux";
+import { Character, RuleTreeItem } from "../../../types";
+import { useEditorSelector } from "../../../hooks/redux";
 import { selectToolId, selectToolItem } from "../../actions/ui-actions";
 import { TOOLS } from "../../constants/constants";
 import { CONTAINER_TYPES } from "../../utils/world-constants";
@@ -33,10 +34,8 @@ export const RuleList = ({
 }) => {
   const { onRuleMoved, onRuleReRecord, onRuleDeleted, onRuleStamped } =
     useContext(RuleActionsContext);
-  const selectedToolId = useSelector<EditorState, TOOLS>((state) => state.ui.selectedToolId);
-  const stampToolItem = useSelector<EditorState, UIState["stampToolItem"]>(
-    (s) => s.ui.stampToolItem,
-  );
+  const selectedToolId = useEditorSelector((state) => state.ui.selectedToolId);
+  const stampToolItem = useEditorSelector((s) => s.ui.stampToolItem);
 
   const dispatch = useDispatch();
 

--- a/frontend/src/editor/components/inspector/transform-editor.tsx
+++ b/frontend/src/editor/components/inspector/transform-editor.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
-import { useSelector } from "react-redux";
 import { Button, Modal, ModalBody, ModalFooter } from "reactstrap";
-import { ActorTransform, Characters, EditorState } from "../../../types";
+import { ActorTransform } from "../../../types";
+import { useEditorSelector } from "../../../hooks/redux";
 import { STAGE_CELL_SIZE } from "../../constants/constants";
 import ActorSprite from "../sprites/actor-sprite";
 import { TransformLabels } from "./transform-images";
@@ -20,7 +20,7 @@ export const TransformEditorModal = ({
   appearance?: string;
   onChange: (value: ActorTransform) => void;
 }) => {
-  const characters = useSelector<EditorState, Characters>((e) => e.characters);
+  const characters = useEditorSelector((e) => e.characters);
   const [transform, setTransform] = useState<ActorTransform>(value);
 
   useEffect(() => {

--- a/frontend/src/editor/components/library.tsx
+++ b/frontend/src/editor/components/library.tsx
@@ -1,6 +1,6 @@
 import classNames from "classnames";
 import React, { useCallback, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 
 import Button from "reactstrap/lib/Button";
 import ButtonDropdown from "reactstrap/lib/ButtonDropdown";
@@ -29,7 +29,8 @@ import {
   showModal,
 } from "../actions/ui-actions";
 
-import { Character, Characters, EditorState, UIState } from "../../types";
+import { Character } from "../../types";
+import { useEditorSelector } from "../../hooks/redux";
 import { defaultAppearanceId } from "../utils/character-helpers";
 import { makeId } from "../utils/utils";
 import Sprite from "./sprites/sprite";
@@ -122,9 +123,9 @@ const CONFIRM_DELETE_CHARACTER = `Are you sure you want to delete this character
 
 export const Library: React.FC = () => {
   const dispatch = useDispatch();
-  const characters = useSelector<EditorState, Characters>((s) => s.characters);
-  const ui = useSelector<EditorState, UIState>((s) => s.ui);
-  const recordingActorId = useSelector<EditorState, string | null>((s) => s.recording.actorId);
+  const characters = useEditorSelector((s) => s.characters);
+  const ui = useEditorSelector((s) => s.ui);
+  const recordingActorId = useEditorSelector((s) => s.recording.actorId);
 
   const [characterDropdownOpen, setCharacterDropdownOpen] = useState(false);
 

--- a/frontend/src/editor/components/modal-explore-characters/container.tsx
+++ b/frontend/src/editor/components/modal-explore-characters/container.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import Button from "reactstrap/lib/Button";
 import Modal from "reactstrap/lib/Modal";
 import ModalBody from "reactstrap/lib/ModalBody";
 import ModalFooter from "reactstrap/lib/ModalFooter";
 
 import { makeRequest } from "../../../helpers/api";
-import { Character, EditorState } from "../../../types";
+import { Character } from "../../../types";
+import { useEditorSelector } from "../../../hooks/redux";
 import { upsertCharacter } from "../../actions/characters-actions";
 import { dismissModal } from "../../actions/ui-actions";
 import { MODALS } from "../../constants/constants";
@@ -66,9 +67,7 @@ const CharacterBrowser = ({ characters, onAddCharacter }: CharacterBrowserProps)
 
 export const ExploreCharactersContainer = () => {
   const dispatch = useDispatch();
-  const open = useSelector<EditorState, boolean>(
-    (state) => state.ui.modal.openId === MODALS.EXPLORE_CHARACTERS,
-  );
+  const open = useEditorSelector((state) => state.ui.modal.openId === MODALS.EXPLORE_CHARACTERS);
   const [characters, setCharacters] = useState<Character[] | null>(null);
 
   useEffect(() => {

--- a/frontend/src/editor/components/modal-keypicker/container.tsx
+++ b/frontend/src/editor/components/modal-keypicker/container.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import Button from "reactstrap/lib/Button";
 import Modal from "reactstrap/lib/Modal";
 import ModalBody from "reactstrap/lib/ModalBody";
 import ModalFooter from "reactstrap/lib/ModalFooter";
 
-import { EditorState } from "../../../types";
+import { useEditorSelector } from "../../../hooks/redux";
 import { upsertRecordingCondition } from "../../actions/recording-actions";
 import { pickConditionValueFromKeyboard } from "../../actions/ui-actions";
 import { makeId } from "../../utils/utils";
@@ -13,10 +13,9 @@ import Keyboard, { keyToCodakoKey } from "./keyboard";
 
 export const KeypickerContainer = () => {
   const dispatch = useDispatch();
-  const { open, initialKey, replaceConditionKey } = useSelector<
-    EditorState,
-    EditorState["ui"]["keypicker"]
-  >((state) => state.ui.keypicker);
+  const { open, initialKey, replaceConditionKey } = useEditorSelector(
+    (state) => state.ui.keypicker,
+  );
 
   const [key, setKey] = useState<string | null>(initialKey);
 

--- a/frontend/src/editor/components/modal-publish/container.tsx
+++ b/frontend/src/editor/components/modal-publish/container.tsx
@@ -1,11 +1,11 @@
 import { useContext, useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import Button from "reactstrap/lib/Button";
 import Modal from "reactstrap/lib/Modal";
 import ModalBody from "reactstrap/lib/ModalBody";
 import ModalFooter from "reactstrap/lib/ModalFooter";
 
-import { EditorState } from "../../../types";
+import { useEditorSelector } from "../../../hooks/redux";
 import { updateWorldMetadata } from "../../actions/world-actions";
 import { dismissModal } from "../../actions/ui-actions";
 import { MODALS, WORLDS } from "../../constants/constants";
@@ -15,12 +15,8 @@ export const PublishContainer = () => {
   const dispatch = useDispatch();
   const { saveWorld } = useContext(EditorContext);
 
-  const open = useSelector<EditorState, boolean>(
-    (state) => state.ui.modal.openId === MODALS.PUBLISH,
-  );
-  const metadata = useSelector<EditorState, EditorState["world"]["metadata"]>(
-    (state) => state.world.metadata,
-  );
+  const open = useEditorSelector((state) => state.ui.modal.openId === MODALS.PUBLISH);
+  const metadata = useEditorSelector((state) => state.world.metadata);
 
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");

--- a/frontend/src/editor/components/modal-stages/container.tsx
+++ b/frontend/src/editor/components/modal-stages/container.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useRef } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import Button from "reactstrap/lib/Button";
 import Modal from "reactstrap/lib/Modal";
 import ModalBody from "reactstrap/lib/ModalBody";
 import ModalFooter from "reactstrap/lib/ModalFooter";
 
-import { EditorState } from "../../../types";
+import { useEditorSelector } from "../../../hooks/redux";
 import { createStage, deleteStageId, updateStageSettings } from "../../actions/stage-actions";
 import { dismissModal, selectStageId } from "../../actions/ui-actions";
 import { MODALS, WORLDS } from "../../constants/constants";
@@ -16,11 +16,9 @@ import { StageSettings } from "./settings";
 export const StagesContainer = () => {
   const dispatch = useDispatch();
   const listEl = useRef<HTMLDivElement>(null);
-  const stage = useSelector(getCurrentStage);
-  const stagesArray = useSelector(getStagesList);
-  const open = useSelector<EditorState, boolean>(
-    (state) => state.ui.modal.openId === MODALS.STAGES,
-  );
+  const stage = useEditorSelector(getCurrentStage);
+  const stagesArray = useEditorSelector(getStagesList);
+  const open = useEditorSelector((state) => state.ui.modal.openId === MODALS.STAGES);
 
   const _scrollToSelectedStage = () => {
     const el = listEl.current;

--- a/frontend/src/editor/components/modal-videos/container.tsx
+++ b/frontend/src/editor/components/modal-videos/container.tsx
@@ -1,18 +1,16 @@
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import Button from "reactstrap/lib/Button";
 import Modal from "reactstrap/lib/Modal";
 import ModalBody from "reactstrap/lib/ModalBody";
 import ModalFooter from "reactstrap/lib/ModalFooter";
 
-import { EditorState } from "../../../types";
+import { useEditorSelector } from "../../../hooks/redux";
 import { dismissModal } from "../../actions/ui-actions";
 import { MODALS } from "../../constants/constants";
 
 export const VideosContainer = () => {
   const dispatch = useDispatch();
-  const open = useSelector<EditorState, boolean>(
-    (state) => state.ui.modal.openId === MODALS.VIDEOS,
-  );
+  const open = useEditorSelector((state) => state.ui.modal.openId === MODALS.VIDEOS);
 
   const _onClose = () => {
     dispatch(dismissModal());

--- a/frontend/src/editor/components/stage/container.tsx
+++ b/frontend/src/editor/components/stage/container.tsx
@@ -1,4 +1,4 @@
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import { RecordingActions } from "./recording/panel-actions";
 import { RecordingConditions } from "./recording/panel-conditions";
 import Stage from "./stage";
@@ -8,14 +8,8 @@ import StageRecordingTools from "./stage-recording-tools";
 
 import { useEffect, useRef, useState } from "react";
 import * as Types from "../../../types";
-import {
-  Characters,
-  EditorState,
-  EvaluatedRuleDetailsMap,
-  EvaluatedSquare,
-  UIState,
-  World,
-} from "../../../types";
+import { EvaluatedRuleDetailsMap, EvaluatedSquare, UIState } from "../../../types";
+import { useEditorSelector } from "../../../hooks/redux";
 import { RECORDING_PHASE } from "../../constants/constants";
 import { getCurrentStageForWorld } from "../../utils/selectors";
 import { Library } from "../library";
@@ -58,15 +52,11 @@ function getEvaluatedSquares(
 
 const StageContainer = ({ readonly }: { readonly?: boolean }) => {
   const dispatch = useDispatch();
-  const recording = useSelector<EditorState, EditorState["recording"]>((state) => state.recording);
-  const characters = useSelector<EditorState, Characters>((state) => state.characters);
-  const world = useSelector<EditorState, World>((state) => state.world);
-  const playback = useSelector<EditorState, EditorState["ui"]["playback"]>(
-    (state) => state.ui.playback,
-  );
-  const selectedActors = useSelector<EditorState, UIState["selectedActors"]>(
-    (state) => state.ui.selectedActors,
-  );
+  const recording = useEditorSelector((state) => state.recording);
+  const characters = useEditorSelector((state) => state.characters);
+  const world = useEditorSelector((state) => state.world);
+  const playback = useEditorSelector((state) => state.ui.playback);
+  const selectedActors = useEditorSelector((state) => state.ui.selectedActors);
 
   let stageA: React.ReactNode | null = null;
   let stageB: React.ReactNode | null = null;

--- a/frontend/src/editor/components/stage/recording/blocks.tsx
+++ b/frontend/src/editor/components/stage/recording/blocks.tsx
@@ -1,12 +1,5 @@
-import { useSelector } from "react-redux";
-import {
-  Actor,
-  ActorTransform,
-  Character,
-  Characters,
-  EditorState,
-  WorldMinimal,
-} from "../../../../types";
+import { Actor, ActorTransform, Character, WorldMinimal } from "../../../../types";
+import { useEditorSelector } from "../../../../hooks/redux";
 import { getCurrentStageForWorld } from "../../../utils/selectors";
 import { TransformLabels } from "../../inspector/transform-images";
 import Sprite from "../../sprites/sprite";
@@ -118,8 +111,8 @@ export const ConnectedActorBlock = ({
   actorId: string;
   recordingWorld?: WorldMinimal;
 }) => {
-  const world = useSelector<EditorState, WorldMinimal>((state) => state.world);
-  const characters = useSelector<EditorState, Characters>((state) => state.characters);
+  const world = useEditorSelector((state) => state.world);
+  const characters = useEditorSelector((state) => state.characters);
   const actor = getCurrentStageForWorld(recordingWorld || world)?.actors[actorId];
   const character = actor && characters[actor.characterId];
   if (actor && character) {

--- a/frontend/src/editor/components/stage/recording/condition-rows.tsx
+++ b/frontend/src/editor/components/stage/recording/condition-rows.tsx
@@ -1,13 +1,12 @@
 import React, { useState } from "react";
 
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import { Button } from "reactstrap";
 import {
   Actor,
   ActorTransform,
   Character,
   Characters,
-  EditorState,
   EvaluatedCondition,
   RuleCondition,
   RuleValue,
@@ -15,6 +14,7 @@ import {
   VariableComparator,
   WorldMinimal,
 } from "../../../../types";
+import { useEditorSelector } from "../../../../hooks/redux";
 import { pickConditionValueFromKeyboard, selectToolId } from "../../../actions/ui-actions";
 import { TOOLS } from "../../../constants/constants";
 import { AppearanceDropdown, TransformDropdown } from "../../inspector/container-pane-variables";
@@ -53,7 +53,7 @@ export const FreeformConditionRow = ({
   onChange,
 }: FreeformConditionRowProps) => {
   const { left, right, comparator } = condition;
-  const selectedToolId = useSelector<EditorState, TOOLS>((state) => state.ui.selectedToolId);
+  const selectedToolId = useEditorSelector((state) => state.ui.selectedToolId);
   const dispatch = useDispatch();
 
   const impliedDatatype: ImpliedDatatype = (() => {
@@ -167,7 +167,7 @@ export const FreeformConditionValue = ({
   conditionId?: string;
   comparator: VariableComparator;
 }) => {
-  const selectedToolId = useSelector<EditorState, TOOLS>((state) => state.ui.selectedToolId);
+  const selectedToolId = useEditorSelector((state) => state.ui.selectedToolId);
   const dispatch = useDispatch();
 
   const [droppingValue, setDroppingValue] = useState(false);

--- a/frontend/src/editor/components/stage/recording/panel-actions.tsx
+++ b/frontend/src/editor/components/stage/recording/panel-actions.tsx
@@ -2,16 +2,10 @@ import { getCurrentStageForWorld } from "../../../utils/selectors";
 
 import classNames from "classnames";
 import React, { useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import { Button } from "reactstrap";
-import {
-  Characters,
-  EditorState,
-  RecordingState,
-  RuleAction,
-  RuleValue,
-  UIState,
-} from "../../../../types";
+import { Characters, RecordingState, RuleAction, RuleValue } from "../../../../types";
+import { useEditorSelector } from "../../../../hooks/redux";
 import { updateRecordingActions } from "../../../actions/recording-actions";
 import { changeActors } from "../../../actions/stage-actions";
 import { selectToolId } from "../../../actions/ui-actions";
@@ -30,7 +24,7 @@ import { VariableActionPicker } from "./variable-action-picker";
 export const RecordingActions = (props: { characters: Characters; recording: RecordingState }) => {
   const { characters, recording } = props;
   const { beforeWorld, actions, extent } = recording;
-  const selectedToolId = useSelector<EditorState, TOOLS>((state) => state.ui.selectedToolId);
+  const selectedToolId = useEditorSelector((state) => state.ui.selectedToolId);
 
   const dispatch = useDispatch();
 
@@ -368,11 +362,9 @@ const StageAfterTools = () => {
   const [open, setOpen] = useState(false);
   const dispatch = useDispatch();
 
-  const characters = useSelector<EditorState, Characters>((state) => state.characters);
-  const selectedActors = useSelector<EditorState, UIState["selectedActors"]>(
-    (state) => state.ui.selectedActors,
-  );
-  const recording = useSelector<EditorState, RecordingState>((state) => state.recording);
+  const characters = useEditorSelector((state) => state.characters);
+  const selectedActors = useEditorSelector((state) => state.ui.selectedActors);
+  const recording = useEditorSelector((state) => state.recording);
   const afterStage = getCurrentStageForWorld(
     getAfterWorldForRecording(recording.beforeWorld, characters, recording),
   );

--- a/frontend/src/editor/components/stage/recording/panel-conditions.tsx
+++ b/frontend/src/editor/components/stage/recording/panel-conditions.tsx
@@ -2,16 +2,15 @@ import React, { useState } from "react";
 
 import { FreeformConditionRow } from "./condition-rows";
 
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import {
   Characters,
-  EditorState,
   EvaluatedCondition,
   EvaluatedRuleDetailsMap,
   RecordingState,
   UIState,
-  World,
 } from "../../../../types";
+import { useEditorSelector } from "../../../../hooks/redux";
 import { upsertRecordingCondition } from "../../../actions/recording-actions";
 import { getCurrentStageForWorld } from "../../../utils/selectors";
 import { actorIntersectsExtent } from "../../../utils/stage-helpers";
@@ -73,10 +72,8 @@ export const RecordingConditions = ({
   const [dropping, setDropping] = useState(false);
 
   // Get the main world to access evaluation details
-  const world = useSelector<EditorState, World>((state) => state.world);
-  const selectedActors = useSelector<EditorState, EditorState["ui"]["selectedActors"]>(
-    (state) => state.ui.selectedActors,
-  );
+  const world = useEditorSelector((state) => state.world);
+  const selectedActors = useEditorSelector((state) => state.ui.selectedActors);
 
   const { beforeWorld, conditions, extent } = recording;
   const stage = getCurrentStageForWorld(beforeWorld);

--- a/frontend/src/editor/components/stage/stage-images-loader.tsx
+++ b/frontend/src/editor/components/stage/stage-images-loader.tsx
@@ -1,12 +1,11 @@
 import { useEffect } from "react";
-import { useSelector } from "react-redux";
 
-import { EditorState, Stage } from "../../../types";
+import { useEditorSelector } from "../../../hooks/redux";
 import { getStagesList } from "../../utils/selectors";
 import { prepareCrossoriginImages } from "../../utils/stage-helpers";
 
 export const StageImagesLoader = () => {
-  const stages = useSelector<EditorState, Stage[]>((state) => getStagesList(state));
+  const stages = useEditorSelector((state) => getStagesList(state));
   useEffect(() => {
     prepareCrossoriginImages(stages);
   }, [stages]);

--- a/frontend/src/editor/components/stage/stage-recording-tools.tsx
+++ b/frontend/src/editor/components/stage/stage-recording-tools.tsx
@@ -1,13 +1,13 @@
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 
 import classNames from "classnames";
 import Button from "reactstrap/lib/Button";
-import { EditorState } from "../../../types";
+import { useEditorSelector } from "../../../hooks/redux";
 import { pickConditionValueFromKeyboard, selectToolId } from "../../actions/ui-actions";
 import { TOOLS } from "../../constants/constants";
 
 const StageRecordingTools = () => {
-  const selectedToolId = useSelector<EditorState, TOOLS>((state) => state.ui.selectedToolId);
+  const selectedToolId = useEditorSelector((state) => state.ui.selectedToolId);
   const dispatch = useDispatch();
 
   return (

--- a/frontend/src/editor/components/stage/stage.tsx
+++ b/frontend/src/editor/components/stage/stage.tsx
@@ -1,5 +1,5 @@
 import React, { CSSProperties, useEffect, useRef, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 
 import ActorSprite from "../sprites/actor-sprite";
 import ActorSelectionPopover from "./actor-selection-popover";
@@ -42,15 +42,13 @@ import {
 
 import {
   Actor,
-  Characters,
-  EditorState,
   EvaluatedSquare,
   Position,
   RuleExtent,
   Stage as StageType,
-  UIState,
   WorldMinimal,
 } from "../../../types";
+import { useEditorSelector } from "../../../hooks/redux";
 import { defaultAppearanceId } from "../../utils/character-helpers";
 import { makeId } from "../../utils/utils";
 import { keyToCodakoKey } from "../modal-keypicker/keyboard";
@@ -129,16 +127,15 @@ export const Stage = ({
   }, [stage.height, stage.scale, stage.width, recordingCentered]);
 
   const dispatch = useDispatch();
-  const characters = useSelector<EditorState, Characters>((state) => state.characters);
-  const { selectedActors, selectedToolId, stampToolItem, playback } = useSelector<
-    EditorState,
-    Pick<UIState, "selectedActors" | "selectedToolId" | "stampToolItem" | "playback">
-  >((state) => ({
-    selectedActors: state.ui.selectedActors,
-    selectedToolId: state.ui.selectedToolId,
-    stampToolItem: state.ui.stampToolItem,
-    playback: state.ui.playback,
-  }));
+  const characters = useEditorSelector((state) => state.characters);
+  const { selectedActors, selectedToolId, stampToolItem, playback } = useEditorSelector(
+    (state) => ({
+      selectedActors: state.ui.selectedActors,
+      selectedToolId: state.ui.selectedToolId,
+      stampToolItem: state.ui.stampToolItem,
+      playback: state.ui.playback,
+    }),
+  );
 
   // Helpers
 

--- a/frontend/src/editor/components/toolbar.tsx
+++ b/frontend/src/editor/components/toolbar.tsx
@@ -1,6 +1,6 @@
 import classNames from "classnames";
 import { useContext, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import { Link } from "react-router-dom";
 
 import Button from "reactstrap/lib/Button";
@@ -17,18 +17,14 @@ import { TapToEditLabel } from "./tap-to-edit-label";
 import UndoRedoControls from "./undo-redo-controls";
 
 import { EditorContext } from "../../components/editor-context";
-import { EditorState, World } from "../../types";
+import { useEditorSelector } from "../../hooks/redux";
 
 const Toolbar = () => {
   const dispatch = useDispatch();
-  const selectedToolId = useSelector<EditorState, string>((state) => state.ui.selectedToolId);
-  const stageName = useSelector<EditorState, string | undefined>(
-    (state) => getCurrentStage(state)?.name,
-  );
-  const metadata = useSelector<EditorState, World["metadata"]>((state) => state.world.metadata);
-  const isInTutorial = useSelector<EditorState, boolean>(
-    (state) => state.ui.tutorial.stepIndex === 0,
-  );
+  const selectedToolId = useEditorSelector((state) => state.ui.selectedToolId);
+  const stageName = useEditorSelector((state) => getCurrentStage(state)?.name);
+  const metadata = useEditorSelector((state) => state.world.metadata);
+  const isInTutorial = useEditorSelector((state) => state.ui.tutorial.stepIndex === 0);
 
   const { usingLocalStorage, saveWorldAnd, saveWorld } = useContext(EditorContext);
   const [open, setOpen] = useState(false);

--- a/frontend/src/editor/components/undo-redo-controls.tsx
+++ b/frontend/src/editor/components/undo-redo-controls.tsx
@@ -1,13 +1,13 @@
 import { useCallback, useEffect } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import Button from "reactstrap/lib/Button";
 import { undo, redo } from "../utils/undo-redo";
-import { EditorState } from "../../types";
+import { useEditorSelector } from "../../hooks/redux";
 
 const UndoRedoControls = () => {
   const dispatch = useDispatch();
-  const undoDepth = useSelector<EditorState, number>((state) => state.undoStack.length);
-  const redoDepth = useSelector<EditorState, number>((state) => state.redoStack.length);
+  const undoDepth = useEditorSelector((state) => state.undoStack.length);
+  const redoDepth = useEditorSelector((state) => state.redoStack.length);
 
   const dispatchAction = useCallback(
     (action: ReturnType<typeof undo> | ReturnType<typeof redo>) => {

--- a/frontend/src/editor/root-editor.tsx
+++ b/frontend/src/editor/root-editor.tsx
@@ -12,13 +12,12 @@ import { StagesContainer } from "./components/modal-stages/container";
 import VideosContainer from "./components/modal-videos/container";
 import { StageImagesLoader } from "./components/stage/stage-images-loader";
 
-import { useSelector } from "react-redux";
-import { EditorState } from "../types";
+import { useEditorSelector } from "../hooks/redux";
 import { StampCursorSupport } from "./components/cursor-support";
 import "./styles/editor.scss";
 
 const RootEditor = () => {
-  const selectedToolId = useSelector<EditorState>((state) => state.ui.selectedToolId);
+  const selectedToolId = useEditorSelector((state) => state.ui.selectedToolId);
 
   return (
     <div className={`editor tool-${selectedToolId}`}>

--- a/frontend/src/hooks/redux.ts
+++ b/frontend/src/hooks/redux.ts
@@ -1,0 +1,9 @@
+import { TypedUseSelectorHook, useSelector } from "react-redux";
+import { MainState } from "../reducers/initial-state";
+import { EditorState } from "../types";
+
+// Typed selector hook for MainState (app-level state: me, worlds, profiles, network)
+export const useAppSelector: TypedUseSelectorHook<MainState> = useSelector;
+
+// Typed selector hook for EditorState (editor-level state: characters, world, ui, recording)
+export const useEditorSelector: TypedUseSelectorHook<EditorState> = useSelector;


### PR DESCRIPTION
Create pre-typed selector hooks using TypedUseSelectorHook from react-redux to eliminate the need to specify type parameters on every useSelector call.

- useAppSelector: for MainState (app-level state like me, worlds, profiles)
- useEditorSelector: for EditorState (editor state like characters, world, ui)

This reduces boilerplate and improves developer experience while maintaining full type safety through TypeScript's inference.