### PR TITLE
Fix cold start EntityMetadataNotFoundError by awaiting TypeORM init

### DIFF
--- a/api/src/db/data-source.ts
+++ b/api/src/db/data-source.ts
@@ -1,5 +1,4 @@
 import { DataSource } from "typeorm";
-import { logger } from "../logger";
 import { User } from "./entity/user";
 import { World } from "./entity/world";
 
@@ -24,8 +23,3 @@ export const AppDataSource = new DataSource({
     poolSize: process.env.DATABASE_POOL_SIZE || 40,
   },
 });
-
-export const initialize =
-  !process.env.SEED && process.env.NODE_ENV !== "test"
-    ? AppDataSource.initialize().catch(logger.error)
-    : null;

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -16,7 +16,7 @@ const WORKERS = Number(process.env.WORKERS || "1");
 function startService(run: () => void) {
   const start = async (pid: number) => {
     logger.info("Initializing database connections");
-    await Promise.all([AppDataSource.initialize]);
+    await AppDataSource.initialize();
 
     logger.info("Starting service...");
     void run();


### PR DESCRIPTION
The server was not properly waiting for TypeORM to initialize before
starting to handle requests. The bug was that `AppDataSource.initialize`
was passed as a reference to Promise.all instead of being called as
`AppDataSource.initialize()`. This caused the server to start immediately
without waiting for the database connection to be established.

Also removed unused `initialize` export from data-source.ts that was
dead code from a previous approach.