### PR TITLE
Enable drag-and-drop of actors into actor-type variable boxes

### DIFF
--- a/frontend/src/editor/styles/editor.scss
+++ b/frontend/src/editor/styles/editor.scss
@@ -734,6 +734,10 @@ html {
     &.variable-set-true {
       background-color: orange;
     }
+    &.dropping-true {
+      border: 2px solid rgba(91, 192, 222, 0.8);
+      background: rgba(91, 192, 222, 0.35);
+    }
 
     .name {
       background-color: transparent;


### PR DESCRIPTION
Add drop target support to VariableGridItem for actor-type variables.
When an actor is dragged from the stage over an actor-type variable box,
the variable box now highlights to indicate it accepts the drop, and
dropping the actor sets the variable value to that actor's ID.