### PR TITLE
Fix Delete World functionality not working

### DIFF
--- a/frontend/src/actions/main-actions.tsx
+++ b/frontend/src/actions/main-actions.tsx
@@ -84,12 +84,12 @@ export function fetchWorld(id: ID) {
 }
 
 export function deleteWorld(id: ID) {
-  return function () {
+  return function (dispatch: Dispatch<MainActions>) {
     if (
       window.confirm("Are you sure you want to delete this world? This action cannot be undone.")
     ) {
       makeRequest(`/worlds/${id}`, { method: "DELETE" }).then(() => {
-        fetchWorldsForUser("me");
+        dispatch(fetchWorldsForUser("me"));
       });
     }
   };


### PR DESCRIPTION
The deleteWorld action was calling fetchWorldsForUser("me") directly after a successful DELETE request, but this is a Redux thunk that needs to be dispatched. Without dispatching, it just created the thunk function and discarded it, so the UI never refreshed after deletion.