### PR TITLE
Save & Exit without Saving with Draft Support

### DIFF
--- a/api/src/db/entity/world.ts
+++ b/api/src/db/entity/world.ts
@@ -19,6 +19,12 @@ export class World {
   @Column({ type: "jsonb", nullable: true })
   data: Record<string, unknown> | null;
 
+  @Column({ type: "text", nullable: true })
+  unsavedData: string | null;
+
+  @Column({ type: "timestamptz", nullable: true })
+  unsavedDataUpdatedAt: Date | null;
+
   @Column({ type: "text" })
   thumbnail: string;
 
@@ -66,6 +72,8 @@ export class World {
       updatedAt: this.updatedAt,
       published: this.published,
       description: this.description,
+      unsavedDataUpdatedAt: this.unsavedDataUpdatedAt,
+      hasUnsavedData: !!this.unsavedData,
     };
   }
 }

--- a/api/src/routes/worlds.ts
+++ b/api/src/routes/worlds.ts
@@ -34,7 +34,7 @@ router.get("/worlds/:objectId", async (req, res) => {
   world.playCount = Number(world.playCount) + 1;
   await AppDataSource.getRepository(World).save(world);
 
-  // Return both data and unsavedData - let frontend decide which to use
+  // Return both data and unsavedData with their timestamps - let frontend decide which to use
   res.json(
     Object.assign({}, world.serialize(), {
       data: world.data,
@@ -157,6 +157,7 @@ router.put("/worlds/:objectId", userFromBasicAuth, async (req, res) => {
     // Allow updating published/description on save
     world.description = req.body.description ?? world.description;
     world.published = req.body.published ?? world.published;
+    // updatedAt will be automatically updated by TypeORM
   } else if (action === "discard") {
     // Discard: clear unsavedData and timestamp
     world.unsavedData = null;
@@ -172,6 +173,7 @@ router.put("/worlds/:objectId", userFromBasicAuth, async (req, res) => {
     // Allow updating published/description during draft save too
     world.description = req.body.description ?? world.description;
     world.published = req.body.published ?? world.published;
+    // Don't update updatedAt when saving draft
   }
 
   await AppDataSource.getRepository(World).save(world);

--- a/frontend/src/components/editor-context.tsx
+++ b/frontend/src/components/editor-context.tsx
@@ -5,8 +5,18 @@ export const EditorContext = React.createContext<{
   usingLocalStorage: boolean;
   saveWorldAnd: (dest: string) => void;
   saveWorld: () => Promise<void>;
+  save: () => Promise<any>;
+  saveDraft: () => Promise<any>;
+  saveAndExit: (dest: string) => void;
+  exitWithoutSaving: (dest: string) => void;
+  hasUnsavedChanges: boolean;
 }>({
   usingLocalStorage: false,
   saveWorldAnd: () => new Error(),
   saveWorld: () => Promise.resolve(),
+  save: () => Promise.resolve(),
+  saveDraft: () => Promise.resolve(),
+  saveAndExit: () => new Error(),
+  exitWithoutSaving: () => new Error(),
+  hasUnsavedChanges: false,
 });

--- a/frontend/src/components/editor-page.tsx
+++ b/frontend/src/components/editor-page.tsx
@@ -91,19 +91,6 @@ const LocalStorageAdapter = {
   },
 };
 
-// static propTypes = {
-//   me: PropTypes.object,
-//   dispatch: PropTypes.func,
-//   location: PropTypes.shape({
-//     query: PropTypes.shape({
-//       localstorage: PropTypes.string,
-//     }),
-//   }),
-//   params: PropTypes.shape({
-//     worldId: PropTypes.string,
-//   }),
-// };
-
 const EditorPage = () => {
   const me = useAppSelector((s) => s.me!);
   const dispatch = useDispatch();
@@ -199,12 +186,6 @@ const EditorPage = () => {
           (!updatedAt || !unsavedDataUpdatedAt || unsavedDataUpdatedAt > updatedAt);
 
         if (hasNewerDraft) {
-          console.log("Found newer draft", {
-            unsavedDataUpdatedAt,
-            updatedAt,
-            hasUnsavedData: !!unsavedData,
-            hasSavedData: !!loaded.data,
-          });
           // Store both versions for user to choose
           // Draft version uses unsavedData (already parsed JSON from backend)
           const draftVersion: Game = {
@@ -404,7 +385,6 @@ const EditorPage = () => {
   };
 
   const revertToSaved = () => {
-    console.log("Reverting to saved version", world);
     // Clear unsavedData and load from data
     Adapter.save(me, worldId, {}, "discard").catch(() => {
       // Ignore errors when discarding

--- a/frontend/src/editor/components/modal-paint/sprite-variables-panel.jsx
+++ b/frontend/src/editor/components/modal-paint/sprite-variables-panel.jsx
@@ -1,0 +1,79 @@
+import PropTypes from "prop-types";
+import React from "react";
+
+class SpriteVariablesPanel extends React.Component {
+  static propTypes = {
+    character: PropTypes.object,
+    actor: PropTypes.object,
+    showVariables: PropTypes.bool,
+    visibleVariables: PropTypes.object,
+    onToggleVariableVisibility: PropTypes.func,
+  };
+
+  render() {
+    const { character, actor, showVariables, visibleVariables, onToggleVariableVisibility } = this.props;
+
+    if (!character) {
+      return null;
+    }
+
+    const variables = character.variables || {};
+    const variableKeys = Object.keys(variables);
+
+    if (variableKeys.length === 0) {
+      return (
+        <div className="sprite-variables-panel" style={{ marginTop: 8 }}>
+          <div style={{ fontSize: 12, color: "#666" }}>
+            No variables defined for this sprite
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div className="sprite-variables-panel" style={{ marginTop: 8 }}>
+        <div style={{ display: "flex", alignItems: "center", marginBottom: 8 }}>
+          <h6 style={{ margin: 0, flex: 1 }}>Sprite Variables</h6>
+        </div>
+        
+        <div style={{ maxHeight: 150, overflowY: "auto" }}>
+          {variableKeys.map((variableId) => {
+            const variable = variables[variableId];
+            const value = actor?.variableValues?.[variableId] || variable.defaultValue || "";
+            const isVisible = visibleVariables[variableId];
+            
+            return (
+              <div
+                key={variableId}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  marginBottom: 4,
+                  padding: "2px 4px",
+                  backgroundColor: isVisible ? "#e3f2fd" : "#f5f5f5",
+                  borderRadius: 3,
+                  fontSize: 11,
+                }}
+              >
+                <input
+                  type="checkbox"
+                  checked={isVisible}
+                  onChange={() => onToggleVariableVisibility(variableId)}
+                  style={{ marginRight: 6 }}
+                />
+                <span style={{ flex: 1, fontWeight: 500 }}>
+                  {variable.name}:
+                </span>
+                <span style={{ color: "#666", marginLeft: 4 }}>
+                  {value}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+}
+
+export default SpriteVariablesPanel;

--- a/frontend/src/editor/components/modal-paint/variable-overlay.jsx
+++ b/frontend/src/editor/components/modal-paint/variable-overlay.jsx
@@ -1,0 +1,116 @@
+import PropTypes from "prop-types";
+import React from "react";
+
+class VariableOverlay extends React.Component {
+  static propTypes = {
+    character: PropTypes.object,
+    actor: PropTypes.object,
+    showVariables: PropTypes.bool,
+    visibleVariables: PropTypes.object,
+    pixelSize: PropTypes.number,
+    imageData: PropTypes.object,
+    stageContext: PropTypes.bool,
+  };
+
+  render() {
+    const { character, actor, showVariables, visibleVariables, pixelSize, imageData, stageContext } = this.props;
+
+    if (!character || !imageData) {
+      return null;
+    }
+
+    const variables = character.variables || {};
+    const variableKeys = Object.keys(variables);
+    const visibleVariableKeys = variableKeys.filter(key => visibleVariables[key]);
+
+    if (visibleVariableKeys.length === 0) {
+      return null;
+    }
+
+    // If in stage context, render smaller and above the sprite
+    if (stageContext) {
+      return (
+        <div
+          style={{
+            position: "absolute",
+            left: "50%",
+            top: -22 - (visibleVariableKeys.length - 1) * 18, // stack above sprite
+            transform: "translateX(-50%)",
+            pointerEvents: "none",
+            zIndex: 10,
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+          }}
+        >
+          {visibleVariableKeys.map((variableId, index) => {
+            const variable = variables[variableId];
+            const displayValue = actor?.variableValues?.[variableId] || variable.defaultValue || "";
+            return (
+              <div
+                key={variableId}
+                style={{
+                  marginBottom: 2,
+                  backgroundColor: "rgba(0, 0, 0, 0.7)",
+                  color: "white",
+                  padding: "1px 4px",
+                  borderRadius: 2,
+                  fontSize: 9,
+                  fontFamily: "monospace",
+                  whiteSpace: "nowrap",
+                  border: "1px solid rgba(255, 255, 255, 0.15)",
+                  boxShadow: "0 1px 2px rgba(0,0,0,0.15)",
+                }}
+              >
+                {variable.name}: {displayValue}
+              </div>
+            );
+          })}
+        </div>
+      );
+    }
+    // Default (paint modal etc)
+    return (
+      <div
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          pointerEvents: "none",
+          zIndex: 10,
+          width: imageData.width * pixelSize,
+          height: imageData.height * pixelSize,
+        }}
+      >
+        {visibleVariableKeys.map((variableId, index) => {
+          const variable = variables[variableId];
+          const displayValue = actor?.variableValues?.[variableId] || variable.defaultValue || "";
+          const x = 10 + (index % 2) * 120;
+          const y = 15 + Math.floor(index / 2) * 20;
+          return (
+            <div
+              key={variableId}
+              style={{
+                position: "absolute",
+                left: x,
+                top: y,
+                backgroundColor: "rgba(0, 0, 0, 0.7)",
+                color: "white",
+                padding: "2px 6px",
+                borderRadius: 3,
+                fontSize: 10,
+                fontFamily: "monospace",
+                whiteSpace: "nowrap",
+                border: "1px solid rgba(255, 255, 255, 0.2)",
+              }}
+            >
+              {variable.name}: {displayValue}
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+}
+
+export default VariableOverlay;

--- a/frontend/src/editor/components/stage/stage.tsx
+++ b/frontend/src/editor/components/stage/stage.tsx
@@ -915,7 +915,7 @@ export const Stage = ({
             height: stage.height * STAGE_CELL_SIZE,
             background: backgroundCSS,
             pointerEvents: "none",
-            filter: "brightness(1) saturate(0.8)",
+            filter: "brightness(0.8) saturate(0.8)",
           }}
         />
 

--- a/frontend/src/editor/components/toolbar.tsx
+++ b/frontend/src/editor/components/toolbar.tsx
@@ -26,7 +26,16 @@ const Toolbar = () => {
   const metadata = useEditorSelector((state) => state.world.metadata);
   const isInTutorial = useEditorSelector((state) => state.ui.tutorial.stepIndex === 0);
 
-  const { usingLocalStorage, saveWorldAnd, saveWorld } = useContext(EditorContext);
+  const {
+    usingLocalStorage,
+    saveWorldAnd,
+    saveWorld,
+    save,
+    saveDraft,
+    saveAndExit,
+    exitWithoutSaving,
+    hasUnsavedChanges,
+  } = useContext(EditorContext);
   const [open, setOpen] = useState(false);
 
   const renderTool = (toolId: TOOLS) => {
@@ -78,7 +87,7 @@ const Toolbar = () => {
     }
 
     return (
-      <div style={{ display: "flex", alignItems: "center" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
         <ButtonDropdown data-tutorial-id="main-menu" isOpen={open} toggle={() => setOpen(!open)}>
           <DropdownToggle>
             <i className="fa fa-ellipsis-v" />
@@ -113,11 +122,23 @@ const Toolbar = () => {
                 Publish Game...
               </DropdownItem>
             )}
-            <DropdownItem divider />
-            <DropdownItem onClick={() => saveWorldAnd("/dashboard")}>Save &amp; Exit</DropdownItem>
           </DropdownMenu>
         </ButtonDropdown>
         <TapToEditLabel className="world-name" value={metadata.name} onChange={onNameChange} />
+        {hasUnsavedChanges && (
+          <span style={{ fontSize: "12px", color: "#ff9800", marginLeft: "8px" }}>
+            Unsaved changes
+          </span>
+        )}
+        <Button color="primary" size="sm" onClick={() => save()}>
+          Save
+        </Button>
+        <Button color="success" size="sm" onClick={() => saveAndExit("/dashboard")}>
+          Save &amp; Exit
+        </Button>
+        <Button color="secondary" size="sm" onClick={() => exitWithoutSaving("/dashboard")}>
+          Exit Without Saving
+        </Button>
       </div>
     );
   };

--- a/frontend/src/editor/components/toolbar.tsx
+++ b/frontend/src/editor/components/toolbar.tsx
@@ -31,7 +31,6 @@ const Toolbar = () => {
     saveWorldAnd,
     saveWorld,
     save,
-    saveDraft,
     saveAndExit,
     exitWithoutSaving,
     hasUnsavedChanges,
@@ -122,6 +121,13 @@ const Toolbar = () => {
                 Publish Game...
               </DropdownItem>
             )}
+            <DropdownItem divider />
+            <DropdownItem onClick={() => saveAndExit("/dashboard")}>
+              Save &amp; Exit
+            </DropdownItem>
+            <DropdownItem onClick={() => exitWithoutSaving("/dashboard")}>
+              Exit Without Saving
+            </DropdownItem>
           </DropdownMenu>
         </ButtonDropdown>
         <TapToEditLabel className="world-name" value={metadata.name} onChange={onNameChange} />
@@ -132,12 +138,6 @@ const Toolbar = () => {
         )}
         <Button color="primary" size="sm" onClick={() => save()}>
           Save
-        </Button>
-        <Button color="success" size="sm" onClick={() => saveAndExit("/dashboard")}>
-          Save &amp; Exit
-        </Button>
-        <Button color="secondary" size="sm" onClick={() => exitWithoutSaving("/dashboard")}>
-          Exit Without Saving
         </Button>
       </div>
     );


### PR DESCRIPTION
### Overview
Replaced auto-save with a manual save system that preserves unsaved drafts in a separate database column, allowing users to restore their work after browser crashes or unexpected exits.

### Database Changes
- Added `unsavedData` column (text, nullable) to `worlds` table to store draft state
- Added `unsavedDataUpdatedAt` column (timestamptz, nullable) to track when drafts were last saved

### Backend Changes
- **GET `/worlds/:objectId`**: Returns both `data` and `unsavedData` with timestamps, allowing frontend to determine which version to load
- **PUT `/worlds/:objectId`**: Supports three actions via query parameter:
  - `action=saveDraft` (default): Saves to `unsavedData` column, updates `unsavedDataUpdatedAt`
  - `action=save`: Commits `unsavedData` to `data`, clears draft
  - `action=discard`: Clears `unsavedData` and timestamp
- Added backward compatibility checks for databases without the new column

### Frontend Changes
- **Auto-save drafts**: Changes are automatically saved to `unsavedData` after 5 seconds of inactivity, and on tab close/browser exit
- **Draft restore modal**: On page load, if a newer draft exists, shows modal prompting user to "Load Draft" or "Revert to Saved"
- **Manual save buttons**:
  - "Save" button: Commits draft to saved state (visible in toolbar)
  - "Save & Exit" / "Exit Without Saving": Moved to dropdown menu
- **UI indicators**: Shows "Unsaved changes" indicator when there are uncommitted changes

### User Experience
- **Before**: Auto-saved every 5 seconds, overwriting saved state
- **After**: 
  - Changes auto-save to draft (preserved on crash/exit)
  - User manually commits with "Save" button
  - Can restore draft on next session if browser crashes
  - Can discard draft and revert to last saved version

### Other Details
- Drafts are preserved even if browser crashes or user closes tab without saving
- Timestamp comparison ensures only newer drafts trigger restore prompt
- Backward compatible with existing databases (gracefully handles missing column)