### PR TITLE
Flatten selection before resizing canvas in paint editor

### DIFF
--- a/frontend/src/editor/components/modal-paint/paint-model.ts
+++ b/frontend/src/editor/components/modal-paint/paint-model.ts
@@ -412,9 +412,12 @@ export class PaintModel {
   updateCanvasSize(dSquaresX: number, dSquaresY: number, offsetX: number, offsetY: number): void {
     if (!this.state.imageData) return;
 
-    const newImageData = getImageDataWithNewFrame(this.state.imageData, {
-      width: this.state.imageData.width + 40 * dSquaresX,
-      height: this.state.imageData.height + 40 * dSquaresY,
+    // Flatten selection into the canvas before resizing
+    const flattenedImageData = getFlattenedImageData(this.state) || this.state.imageData;
+
+    const newImageData = getImageDataWithNewFrame(flattenedImageData, {
+      width: flattenedImageData.width + 40 * dSquaresX,
+      height: flattenedImageData.height + 40 * dSquaresY,
       offsetX: 40 * offsetX,
       offsetY: 40 * offsetY,
     });


### PR DESCRIPTION
## Summary
Fixed canvas resizing behavior in the paint editor to flatten any active selection into the canvas before applying the resize operation. This ensures that selections don't cause unexpected behavior when the canvas dimensions are modified.

## Changes
- Modified `updateCanvasSize()` method in `PaintModel` to call `getFlattenedImageData()` before resizing
- The flattened image data is now used as the base for the new frame calculation instead of the raw image data
- This prevents selection artifacts from interfering with canvas resize operations

## Implementation Details
- Added a comment explaining the flatten operation for clarity
- Falls back to the original `imageData` if `getFlattenedImageData()` returns null
- The flatten operation is performed once before the resize, maintaining performance