### PR TITLE
Add ability to enable/disable rules from the inspector UI

### DIFF
--- a/frontend/src/editor/components/inspector/content-event-group.tsx
+++ b/frontend/src/editor/components/inspector/content-event-group.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useContext, useState } from "react";
 import { DisclosureTriangle } from "./disclosure-triangle";
 import { RuleList } from "./rule-list";
 import { RuleStateCircle } from "./rule-state-circle";
@@ -6,6 +6,7 @@ import { RuleStateCircle } from "./rule-state-circle";
 import { Character, RuleTreeEventItem } from "../../../types";
 import { nameForKey } from "../../utils/event-helpers";
 import { isCollapsePersisted, persistCollapsedState } from "./collapse-state-storage";
+import { RuleActionsContext } from "./container-pane-rules";
 
 export const ContentEventGroup = ({
   rule,
@@ -15,6 +16,7 @@ export const ContentEventGroup = ({
   character: Character;
 }) => {
   const [collapsed, setCollapsed] = useState(isCollapsePersisted(rule.id));
+  const { onRuleChanged } = useContext(RuleActionsContext);
 
   const _name = () => {
     const { event, code } = rule;
@@ -38,7 +40,10 @@ export const ContentEventGroup = ({
     <div>
       <div className="header">
         <div style={{ float: "left", width: 20, lineHeight: "1.15em" }}>
-          <RuleStateCircle rule={rule} />
+          <RuleStateCircle
+            rule={rule}
+            onToggle={() => onRuleChanged(rule.id, { enabled: rule.enabled === false })}
+          />
           <DisclosureTriangle
             onClick={() => {
               setCollapsed(!collapsed);

--- a/frontend/src/editor/components/inspector/content-flow-group.tsx
+++ b/frontend/src/editor/components/inspector/content-flow-group.tsx
@@ -73,7 +73,10 @@ export const ContentFlowGroup = ({
     <div>
       <div className={`${rule.behavior}`}>
         <div style={{ display: "flex", gap: 4, alignItems: "baseline" }}>
-          <RuleStateCircle rule={rule} />
+          <RuleStateCircle
+            rule={rule}
+            onToggle={() => onRuleChanged(rule.id, { enabled: rule.enabled === false })}
+          />
           <TapToEditLabel className="name" value={rule.name} onChange={_onNameChange} />
         </div>
 

--- a/frontend/src/editor/components/inspector/content-rule.tsx
+++ b/frontend/src/editor/components/inspector/content-rule.tsx
@@ -48,7 +48,10 @@ export const ContentRule = ({ rule }: { rule: Rule }) => {
   return (
     <div>
       <div className="scenario">
-        <RuleStateCircle rule={rule} />
+        <RuleStateCircle
+          rule={rule}
+          onToggle={() => onRuleChanged(rule.id, { enabled: rule.enabled === false })}
+        />
         <div style={{ flex: 1 }} />
         <ScenarioStage rule={rule} applyActions={false} maxWidth={75} maxHeight={75} />
         <i className="fa fa-arrow-right" aria-hidden="true" />

--- a/frontend/src/editor/components/inspector/rule-list.tsx
+++ b/frontend/src/editor/components/inspector/rule-list.tsx
@@ -203,7 +203,7 @@ export const RuleList = ({
         draggable
         key={r.id}
         data-rule-id={r.id}
-        className={`rule-container tool-supported ${r.type} ${dragState.hovering === r.id && "hovering"}`}
+        className={`rule-container tool-supported ${r.type} ${dragState.hovering === r.id && "hovering"} ${r.enabled === false && "rule-disabled"}`}
         onClick={(event) => _onRuleClicked(event, r)}
         onDoubleClick={(event) => _onRuleDoubleClick(event, r)}
         onDragStart={(event) => _onDragStart(event, r)}

--- a/frontend/src/editor/components/inspector/rule-state-circle.tsx
+++ b/frontend/src/editor/components/inspector/rule-state-circle.tsx
@@ -1,11 +1,37 @@
 import { useContext } from "react";
 import { InspectorContext } from "./inspector-context";
 
-export const RuleStateCircle = ({ rule }: { rule: { id: string } }) => {
+export const RuleStateCircle = ({
+  rule,
+  onToggle,
+}: {
+  rule: { id: string; enabled?: boolean };
+  onToggle?: () => void;
+}) => {
   const { evaluatedRuleDetailsForActor } = useContext(InspectorContext);
   const details = evaluatedRuleDetailsForActor?.[rule.id];
-  if (details === undefined) {
-    return null;
-  }
-  return <div className={`circle ${details.passed}`} />;
+  const isEnabled = rule.enabled !== false;
+
+  // When rule is disabled, show a gray/muted circle regardless of evaluation
+  // When enabled, show the evaluation result (or nothing if not evaluated)
+  const getCircleClass = () => {
+    if (!isEnabled) {
+      return "circle disabled";
+    }
+    if (details === undefined) {
+      return "circle";
+    }
+    return `circle ${details.passed}`;
+  };
+
+  return (
+    <button
+      className={`rule-toggle-btn ${getCircleClass()}`}
+      onClick={(e) => {
+        e.stopPropagation();
+        onToggle?.();
+      }}
+      title={isEnabled ? "Click to disable rule" : "Click to enable rule"}
+    />
+  );
 };

--- a/frontend/src/editor/components/stage/recording/condition-rows.tsx
+++ b/frontend/src/editor/components/stage/recording/condition-rows.tsx
@@ -37,10 +37,17 @@ type ImpliedDatatype =
   | { type: "actor" }
   | null;
 
-/** Status circle for condition evaluation - hidden when not evaluated */
-const ConditionStatusCircle = ({ status }: { status?: EvaluatedCondition }) => {
+/** Status circle for condition evaluation */
+const ConditionStatusCircle = ({
+  status,
+  alwaysShow,
+}: {
+  status?: EvaluatedCondition;
+  alwaysShow?: boolean;
+}) => {
   if (status === undefined) {
-    return null;
+    // In sidebar mode (alwaysShow), show gray circle; in editor mode, hide
+    return alwaysShow ? <div className="circle" /> : null;
   }
   return <div className={`circle ${status.passed}`} />;
 };
@@ -103,7 +110,7 @@ export const FreeformConditionRow = ({
 
   return (
     <li className={`enabled-true tool-supported`} onClick={onToolClick}>
-      <ConditionStatusCircle status={conditionStatus} />
+      <ConditionStatusCircle status={conditionStatus} alwaysShow={!onChange} />
       <FreeformConditionValue
         conditionId={condition.key}
         value={left}

--- a/frontend/src/editor/styles/editor.scss
+++ b/frontend/src/editor/styles/editor.scss
@@ -92,7 +92,7 @@ html {
     width: 12px;
     height: 12px;
     border-radius: 12px;
-    background-color: transparent;
+    background-color: rgba(0, 0, 0, 0.15);
     border: 1px solid rgba(0, 0, 0, 0.2);
     &.true {
       background-color: #74e535;

--- a/frontend/src/editor/styles/editor.scss
+++ b/frontend/src/editor/styles/editor.scss
@@ -100,6 +100,26 @@ html {
     &.false {
       background-color: red;
     }
+    &.disabled {
+      background-color: #ccc;
+      border-color: rgba(0, 0, 0, 0.1);
+    }
+  }
+
+  .rule-toggle-btn {
+    padding: 0;
+    cursor: pointer;
+    flex-shrink: 0;
+    transition: transform 0.1s ease, box-shadow 0.1s ease;
+
+    &:hover {
+      transform: scale(1.2);
+      box-shadow: 0 0 4px rgba(0, 0, 0, 0.3);
+    }
+
+    &:active {
+      transform: scale(1.1);
+    }
   }
 
   .loading {
@@ -949,6 +969,21 @@ html {
         border-color: transparent transparent transparent rgba(0, 0, 0, 0.4);
       }
       &.enabled {
+        opacity: 1;
+      }
+    }
+
+    &.rule-disabled {
+      opacity: 0.5;
+
+      .scenario,
+      .header,
+      .name,
+      .conditions {
+        opacity: 0.7;
+      }
+
+      .rule-toggle-btn {
         opacity: 1;
       }
     }

--- a/frontend/src/editor/styles/editor.scss
+++ b/frontend/src/editor/styles/editor.scss
@@ -111,11 +111,28 @@ html {
     cursor: pointer;
     flex-shrink: 0;
     pointer-events: auto;
+    position: relative;
     transition: transform 0.1s ease, box-shadow 0.1s ease;
+
+    &::after {
+      content: "";
+      position: absolute;
+      top: 50%;
+      left: -1px;
+      width: 14px;
+      height: 2px;
+      background-color: rgba(0, 0, 0, 0.6);
+      transform: translateY(-50%) rotate(-45deg);
+      opacity: 0;
+      transition: opacity 0.1s ease;
+    }
 
     &:hover {
       transform: scale(1.2);
-      box-shadow: 0 0 4px rgba(0, 0, 0, 0.3);
+
+      &::after {
+        opacity: 1;
+      }
     }
 
     &:active {

--- a/frontend/src/editor/styles/editor.scss
+++ b/frontend/src/editor/styles/editor.scss
@@ -110,6 +110,7 @@ html {
     padding: 0;
     cursor: pointer;
     flex-shrink: 0;
+    pointer-events: auto;
     transition: transform 0.1s ease, box-shadow 0.1s ease;
 
     &:hover {

--- a/frontend/src/editor/utils/world-operator.ts
+++ b/frontend/src/editor/utils/world-operator.ts
@@ -208,6 +208,11 @@ export default function WorldOperator(previousWorld: WorldMinimal, characters: C
         matchedActors: {},
       };
 
+      // Skip disabled rules
+      if (rule.enabled === false) {
+        return emptyDetails;
+      }
+
       if (rule.type === CONTAINER_TYPES.EVENT) {
         const eventPassed = checkEvent(rule);
         if (!eventPassed) {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -101,6 +101,7 @@ export type RuleTreeEventItem = {
   event: "idle" | "key" | "click";
   code?: number; // used for key event
   id: string;
+  enabled?: boolean;
 };
 
 export type RuleTreeFlowItemCheck = {
@@ -116,6 +117,7 @@ export type RuleTreeFlowItemBase = {
   name: string;
   rules: RuleTreeItem[];
   id: string;
+  enabled?: boolean;
 
   check?: RuleTreeFlowItemCheck;
 };
@@ -178,6 +180,7 @@ export type Rule = {
   extent: RuleExtent;
   id: string;
   name: string;
+  enabled?: boolean;
 };
 
 export type Actor = {


### PR DESCRIPTION
## Summary
This PR adds the ability to toggle rules on and off directly from the inspector UI by clicking on the rule state circle. Disabled rules are visually distinguished and are skipped during rule evaluation.

## Key Changes
- **RuleStateCircle component**: Converted from a display-only div to an interactive button that triggers the `onToggle` callback when clicked
  - Added visual feedback with hover/active states (scale transform and shadow)
  - Shows a disabled state (gray circle) when rule is disabled
  - Added tooltip indicating the action ("Click to disable/enable rule")

- **Rule evaluation**: Modified `WorldOperator` to skip evaluation of disabled rules, returning empty details immediately

- **Type definitions**: Added optional `enabled` property to `Rule`, `RuleTreeEventItem`, and `RuleTreeFlowItemBase` types

- **Visual styling**: 
  - Added `.rule-disabled` class to dim disabled rules in the rule list (50% opacity)
  - Added `.rule-toggle-btn` styles with hover/active animations
  - Added `.disabled` circle style (gray background)

- **Component updates**: Updated `ContentEventGroup`, `ContentFlowGroup`, and `ContentRule` to pass the `onToggle` callback to `RuleStateCircle`

- **Rule list styling**: Added `rule-disabled` class to rule containers when `enabled === false`

## Implementation Details
- The toggle action calls `onRuleChanged(rule.id, { enabled: rule.enabled === false })` to flip the enabled state
- Disabled rules maintain their visual distinction throughout the UI while remaining in the rule tree
- The implementation uses React context (`RuleActionsContext`) to access the `onRuleChanged` callback
- Event propagation is stopped on circle click to prevent triggering parent click handlers