### PR TITLE
Improve drag-and-drop targeting for rules list

### DIFF
--- a/frontend/src/editor/components/inspector/rule-list.tsx
+++ b/frontend/src/editor/components/inspector/rule-list.tsx
@@ -79,13 +79,20 @@ export const RuleList = ({
     );
     for (let i = 0; i < all.length; i++) {
       const { top, height } = all[i].getBoundingClientRect();
+      const isLastItem = i === all.length - 1;
+
       if (event.clientY < top + Math.min(50, height * 0.33)) {
         return i;
       }
 
       // create a dead zone within the item. This is crucial for the drop-zones
-      // within the item (ala nested rule list).
-      if (event.clientY < top + Math.max(height - 50, height * 0.66)) {
+      // within the item (ala nested rule list). For the last item, the dead zone
+      // ends at 50% to make it easier to drop at the end of the list.
+      const deadZoneEnd = isLastItem
+        ? top + height * 0.5
+        : top + Math.max(height - 50, height * 0.66);
+
+      if (event.clientY < deadZoneEnd) {
         return DROP_INDEX_INSIDE_BUT_INDETERMINATE;
       }
     }

--- a/frontend/src/editor/styles/editor.scss
+++ b/frontend/src/editor/styles/editor.scss
@@ -609,6 +609,14 @@ html {
     .scroll-container-contents {
       position: absolute;
       width: 100%;
+      min-height: 100%;
+      display: flex;
+      flex-direction: column;
+
+      // Make the top-level rules-list fill the container for easier drop targeting
+      > .rules-list {
+        flex: 1;
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
Enhanced the drag-and-drop experience for the rules list by improving drop zone detection and making the list container fill its parent for better drop targeting.

## Key Changes
- **Adjusted dead zone calculation for last item**: Modified the drop zone logic to use a 50% height threshold for the last item in the rules list, making it easier to drop items at the end of the list compared to the standard 66% threshold used for other items
- **Expanded rules list container**: Added `min-height: 100%` to both the scroll container contents and the top-level rules list to ensure the list fills its parent container, improving the drop target area

## Implementation Details
- The dead zone (area where drops are indeterminate/nested) now dynamically adjusts based on whether an item is the last in the list
- For the last item, the dead zone ends at 50% of the item's height instead of the usual `Math.max(height - 50, height * 0.66)`, reducing the area where users must drop to place items after the last rule
- The CSS changes ensure the rules list container expands to fill available vertical space, preventing dead zones below the visible list items