### PR TITLE
Fix actor selection popover layout for transformed actors

### DIFF
--- a/frontend/src/editor/components/stage/actor-selection-popover.tsx
+++ b/frontend/src/editor/components/stage/actor-selection-popover.tsx
@@ -1,8 +1,55 @@
 import React, { useEffect, useRef } from "react";
-import { Actor, Characters } from "../../../types";
+import { Actor, ActorTransform, AppearanceInfo, Characters } from "../../../types";
 import { STAGE_CELL_SIZE } from "../../constants/constants";
+import { pointApplyingTransform } from "../../utils/stage-helpers";
 import ActorSprite from "../sprites/actor-sprite";
 import { DEFAULT_APPEARANCE_INFO } from "../sprites/sprite";
+
+/**
+ * Calculate the visual bounds and position offset needed to render a transformed
+ * actor within a container. When an actor has a transform (rotation/flip), the
+ * visual bounding box changes and may shift relative to the anchor point.
+ *
+ * Returns the container dimensions (in cells) and the position offset needed
+ * so the actor's visual fits starting at (0, 0).
+ */
+function getTransformedBounds(
+  info: AppearanceInfo,
+  transform: ActorTransform | undefined,
+): { offsetX: number; offsetY: number; width: number; height: number } {
+  const t = transform ?? "0";
+
+  // Calculate where the anchor ends up after transform
+  const [anchorX, anchorY] = pointApplyingTransform(info.anchor.x, info.anchor.y, info, t);
+
+  // Find the bounding box of all cells after transform
+  let minX = Infinity,
+    minY = Infinity,
+    maxX = -Infinity,
+    maxY = -Infinity;
+
+  for (let dx = 0; dx < info.width; dx++) {
+    for (let dy = 0; dy < info.height; dy++) {
+      const [sx, sy] = pointApplyingTransform(dx, dy, info, t);
+      // Position relative to anchor (how ActorSprite calculates grid positions)
+      const x = sx - anchorX;
+      const y = sy - anchorY;
+      minX = Math.min(minX, x);
+      minY = Math.min(minY, y);
+      maxX = Math.max(maxX, x);
+      maxY = Math.max(maxY, y);
+    }
+  }
+
+  return {
+    // Position offset needed so the visual starts at (0, 0)
+    offsetX: -minX,
+    offsetY: -minY,
+    // Visual dimensions in cells
+    width: maxX - minX + 1,
+    height: maxY - minY + 1,
+  };
+}
 
 interface ActorSelectionPopoverProps {
   actors: Actor[];
@@ -67,20 +114,24 @@ const ActorSelectionPopover: React.FC<ActorSelectionPopoverProps> = ({
 
           if (!character) return null;
 
+          // Calculate transformed bounds to properly size container and position sprite
+          const bounds = getTransformedBounds(info, actor.transform);
+
           return (
             <div
               key={actor.id}
               className="actor-option"
               style={{
-                width: info.width * STAGE_CELL_SIZE + 8,
-                height: info.height * STAGE_CELL_SIZE + 8,
+                width: bounds.width * STAGE_CELL_SIZE + 8,
+                height: bounds.height * STAGE_CELL_SIZE + 8,
                 padding: 2,
+                overflow: "hidden",
               }}
             >
               <div style={{ position: "relative" }}>
                 <ActorSprite
                   character={character}
-                  actor={{ ...actor, position: { x: 0, y: 0 } }}
+                  actor={{ ...actor, position: { x: bounds.offsetX, y: bounds.offsetY } }}
                   selected={false}
                   dragActorIds={[actor.id]}
                   onMouseUp={() => onSelect(actor)}

--- a/frontend/src/editor/components/stage/actor-selection-popover.tsx
+++ b/frontend/src/editor/components/stage/actor-selection-popover.tsx
@@ -1,55 +1,9 @@
 import React, { useEffect, useRef } from "react";
-import { Actor, ActorTransform, AppearanceInfo, Characters } from "../../../types";
+import { Actor, Characters } from "../../../types";
 import { STAGE_CELL_SIZE } from "../../constants/constants";
-import { pointApplyingTransform } from "../../utils/stage-helpers";
+import { getTransformedBounds } from "../../utils/stage-helpers";
 import ActorSprite from "../sprites/actor-sprite";
 import { DEFAULT_APPEARANCE_INFO } from "../sprites/sprite";
-
-/**
- * Calculate the visual bounds and position offset needed to render a transformed
- * actor within a container. When an actor has a transform (rotation/flip), the
- * visual bounding box changes and may shift relative to the anchor point.
- *
- * Returns the container dimensions (in cells) and the position offset needed
- * so the actor's visual fits starting at (0, 0).
- */
-function getTransformedBounds(
-  info: AppearanceInfo,
-  transform: ActorTransform | undefined,
-): { offsetX: number; offsetY: number; width: number; height: number } {
-  const t = transform ?? "0";
-
-  // Calculate where the anchor ends up after transform
-  const [anchorX, anchorY] = pointApplyingTransform(info.anchor.x, info.anchor.y, info, t);
-
-  // Find the bounding box of all cells after transform
-  let minX = Infinity,
-    minY = Infinity,
-    maxX = -Infinity,
-    maxY = -Infinity;
-
-  for (let dx = 0; dx < info.width; dx++) {
-    for (let dy = 0; dy < info.height; dy++) {
-      const [sx, sy] = pointApplyingTransform(dx, dy, info, t);
-      // Position relative to anchor (how ActorSprite calculates grid positions)
-      const x = sx - anchorX;
-      const y = sy - anchorY;
-      minX = Math.min(minX, x);
-      minY = Math.min(minY, y);
-      maxX = Math.max(maxX, x);
-      maxY = Math.max(maxY, y);
-    }
-  }
-
-  return {
-    // Position offset needed so the visual starts at (0, 0)
-    offsetX: -minX,
-    offsetY: -minY,
-    // Visual dimensions in cells
-    width: maxX - minX + 1,
-    height: maxY - minY + 1,
-  };
-}
 
 interface ActorSelectionPopoverProps {
   actors: Actor[];

--- a/frontend/src/editor/styles/editor.scss
+++ b/frontend/src/editor/styles/editor.scss
@@ -812,6 +812,7 @@ html {
 
   .actor-selection-popover-content {
     display: flex;
+    flex-direction: column;
     gap: 4px;
   }
 

--- a/frontend/src/editor/utils/stage-helpers.ts
+++ b/frontend/src/editor/utils/stage-helpers.ts
@@ -120,6 +120,45 @@ export function pointApplyingTransform(
   return [x, y];
 }
 
+/**
+ * Calculate the visual bounds and position offset needed to render a transformed
+ * sprite within a container. When a transform (rotation/flip) is applied, the
+ * visual bounding box changes and may shift relative to the anchor point.
+ *
+ * Returns the container dimensions (in cells) and the position offset needed
+ * so the sprite's visual fits starting at (0, 0).
+ */
+export function getTransformedBounds(
+  info: { width: number; height: number; anchor: { x: number; y: number } },
+  transform: Actor["transform"],
+): { offsetX: number; offsetY: number; width: number; height: number } {
+  // Transform anchor and corners to find the bounding box
+  const [anchorX, anchorY] = pointApplyingTransform(info.anchor.x, info.anchor.y, info, transform);
+
+  // Transform all four corners and find min/max
+  const corners = [
+    [0, 0],
+    [info.width - 1, 0],
+    [0, info.height - 1],
+    [info.width - 1, info.height - 1],
+  ].map(([x, y]) => {
+    const [tx, ty] = pointApplyingTransform(x, y, info, transform);
+    return [tx - anchorX, ty - anchorY];
+  });
+
+  const minX = Math.min(...corners.map(([x]) => x));
+  const maxX = Math.max(...corners.map(([x]) => x));
+  const minY = Math.min(...corners.map(([, y]) => y));
+  const maxY = Math.max(...corners.map(([, y]) => y));
+
+  return {
+    offsetX: -minX,
+    offsetY: -minY,
+    width: maxX - minX + 1,
+    height: maxY - minY + 1,
+  };
+}
+
 export function shuffleArray<T>(input: Array<T>): Array<T> {
   const d = [...input]; // Create a copy to avoid mutating input
   for (let c = d.length - 1; c > 0; c--) {


### PR DESCRIPTION
## Summary
Fixed the actor selection popover to correctly display actors with transforms (rotation/flip) by calculating their visual bounds and positioning them appropriately within the container.

## Key Changes
- Added `getTransformedBounds()` utility function that calculates the visual bounding box of a transformed actor by:
  - Applying the transform to all cells of the actor's sprite
  - Computing the bounding box relative to the anchor point
  - Returning the container dimensions and position offset needed for proper rendering
- Updated the popover container to use transformed bounds instead of raw sprite dimensions
- Applied the calculated offset to the actor's position when rendering the sprite
- Added `overflow: hidden` to the container to clip any content outside bounds

## Implementation Details
The function works by iterating through all cells of the sprite, applying the transform to each point, and tracking the min/max coordinates relative to the anchor point. This ensures the visual representation fits correctly within the container regardless of rotation or flip state.