### PR TITLE
Fix close button icon rotation in editor

### DIFF
--- a/frontend/src/editor/styles/editor.scss
+++ b/frontend/src/editor/styles/editor.scss
@@ -122,7 +122,7 @@ html {
       width: 14px;
       height: 2px;
       background-color: rgba(0, 0, 0, 0.6);
-      transform: translateY(-50%) rotate(-45deg);
+      transform: translateY(-50%) rotate(45deg);
       opacity: 0;
       transition: opacity 0.1s ease;
     }


### PR DESCRIPTION
## Summary
Corrected the rotation angle of the close button icon in the editor from -45 degrees to 45 degrees to properly display an "X" symbol.

## Changes
- Updated the CSS transform property for the close button's pseudo-element from `rotate(-45deg)` to `rotate(45deg)` in `frontend/src/editor/styles/editor.scss`

## Details
The close button icon is created using a pseudo-element (likely `::before` or `::after`) that renders as a horizontal line. By rotating this line, it creates an "X" shape. The previous rotation of -45 degrees was displaying the icon incorrectly. The corrected 45-degree rotation now properly aligns the icon to form a visually correct close button.

https://claude.ai/code/session_01S8EjWwZPJM6oNrnXxBpZm6