### PR TITLE
Replace X/Y coordinate labels with Horizontal/Vertical

### DIFF
--- a/frontend/src/editor/components/inspector/container-pane-variables.tsx
+++ b/frontend/src/editor/components/inspector/container-pane-variables.tsx
@@ -191,7 +191,7 @@ const PositionGridItem = ({ actor, coordinate, value, onChange }: PositionGridIt
 
   return (
     <div className={`variable-box variable-set-${!isMixed}`} draggable={!isMixed} onDragStart={_onDragStart}>
-      <div className="name">{coordinate.toUpperCase()}</div>
+      <div className="name">{coordinate === "x" ? "Horizontal" : "Vertical"}</div>
       <input
         type="number"
         value={isMixed ? "" : value}

--- a/frontend/src/editor/components/stage/recording/blocks.tsx
+++ b/frontend/src/editor/components/stage/recording/blocks.tsx
@@ -65,8 +65,8 @@ export const ActorVariableBlock = ({
   const getVariableLabel = () => {
     if (variableId === "transform") return "direction";
     if (variableId === "appearance") return "appearance";
-    if (variableId === "x") return "X";
-    if (variableId === "y") return "Y";
+    if (variableId === "x") return "Horizontal";
+    if (variableId === "y") return "Vertical";
     return <VariableBlock name={(variableId && character.variables[variableId]?.name) || ""} />;
   };
 


### PR DESCRIPTION
## Summary
Updated coordinate axis labels throughout the editor UI to use more user-friendly terminology. Changed "X" and "Y" labels to "Horizontal" and "Vertical" respectively for better clarity and accessibility.

## Changes
- **Container Pane Variables**: Updated the position grid item display to show "Horizontal" for x-coordinate and "Vertical" for y-coordinate instead of uppercase axis letters
- **Recording Blocks**: Updated the actor variable block labels to use "Horizontal" and "Vertical" terminology for x and y position variables

## Details
This change improves the user experience by using descriptive directional terms instead of mathematical axis notation, making the interface more intuitive for users who may not be familiar with coordinate systems. The labels now clearly indicate the direction of movement rather than abstract axis names.

https://claude.ai/code/session_013uJuQDR941eu315tTJPmDq