### PR TITLE
Reorganize toolbar menu and add duplicate world functionality

### DIFF
--- a/frontend/src/editor/components/toolbar.tsx
+++ b/frontend/src/editor/components/toolbar.tsx
@@ -17,6 +17,7 @@ import { TapToEditLabel } from "./tap-to-edit-label";
 import UndoRedoControls from "./undo-redo-controls";
 
 import { EditorContext } from "../../components/editor-context";
+import { createWorld } from "../../actions/main-actions";
 import { useEditorSelector } from "../../hooks/redux";
 
 const Toolbar = () => {
@@ -92,6 +93,22 @@ const Toolbar = () => {
             <i className="fa fa-ellipsis-v" />
           </DropdownToggle>
           <DropdownMenu>
+            <DropdownItem onClick={() => save()}>Save Changes</DropdownItem>
+            <DropdownItem onClick={() => saveAndExit("/dashboard")}>
+              Save &amp; Exit
+            </DropdownItem>
+            <DropdownItem onClick={() => exitWithoutSaving("/dashboard")}>
+              Exit Without Saving
+            </DropdownItem>
+            <DropdownItem divider />
+            <DropdownItem
+              onClick={() => {
+                save().then(() => dispatch(createWorld({ from: metadata.id })));
+              }}
+            >
+              Duplicate This World
+            </DropdownItem>
+            <DropdownItem divider />
             <DropdownItem onClick={() => saveWorldAnd(`/play/${metadata.id}`)}>
               Switch to Player View...
             </DropdownItem>
@@ -121,13 +138,6 @@ const Toolbar = () => {
                 Publish Game...
               </DropdownItem>
             )}
-            <DropdownItem divider />
-            <DropdownItem onClick={() => saveAndExit("/dashboard")}>
-              Save &amp; Exit
-            </DropdownItem>
-            <DropdownItem onClick={() => exitWithoutSaving("/dashboard")}>
-              Exit Without Saving
-            </DropdownItem>
           </DropdownMenu>
         </ButtonDropdown>
         <TapToEditLabel className="world-name" value={metadata.name} onChange={onNameChange} />
@@ -136,9 +146,6 @@ const Toolbar = () => {
             Unsaved changes
           </span>
         )}
-        <Button color="primary" size="sm" onClick={() => save()}>
-          Save
-        </Button>
       </div>
     );
   };


### PR DESCRIPTION
## Summary
Restructured the editor toolbar dropdown menu to improve UX by reorganizing menu items and adding a new "Duplicate This World" feature. The standalone Save button has been consolidated into the dropdown menu.

## Key Changes
- **Added "Duplicate This World" option** to the dropdown menu that saves the current world and creates a copy using the `createWorld` action
- **Reorganized dropdown menu structure** for better logical grouping:
  - Moved "Save Changes" to the top of the menu
  - Grouped save/exit operations together at the top
  - Moved "Duplicate This World" to its own section
  - Kept view-switching and publishing options at the bottom
- **Removed standalone Save button** from the toolbar and consolidated it into the dropdown menu as "Save Changes"
- **Imported `createWorld` action** from main-actions to support the duplicate functionality

## Implementation Details
- The "Duplicate This World" action chains `save()` with `createWorld({ from: metadata.id })` to ensure the current state is persisted before duplication
- Menu items are now organized with dividers to create logical sections
- All save/exit operations remain accessible but are now grouped more intuitively in the dropdown

https://claude.ai/code/session_01WcdgauV8Sgc4wKFQEy5chq