### PR TITLE
Replace readonly prop with interactionMode for granular stage interaction control

### DIFF
--- a/frontend/src/editor/components/stage/container.tsx
+++ b/frontend/src/editor/components/stage/container.tsx
@@ -82,6 +82,7 @@ const StageContainer = ({ readonly }: { readonly?: boolean }) => {
           recordingExtent={recording.extent}
           recordingCentered
           evaluatedSquares={evaluatedSquares}
+          interactionMode="none"
         />
       );
       if (recording.actions !== null) {
@@ -163,7 +164,13 @@ const StageContainer = ({ readonly }: { readonly?: boolean }) => {
     <div className="stage-container">
       <div className="panel stages">
         <div className="stages-horizontal-flex">
-          {stageA || <Stage world={world} stage={current.stage} readonly={readonly} />}
+          {stageA || (
+            <Stage
+              world={world}
+              stage={current.stage}
+              interactionMode={readonly ? "selectable" : "full"}
+            />
+          )}
           {stageB || <Stage stage={0 as never} world={0 as never} style={{ flex: 0 }} />}
         </div>
         {actions || <div className="recording-specifics" style={{ height: 0 }} />}


### PR DESCRIPTION
## Summary
Refactors the Stage component's interaction control system from a simple boolean `readonly` prop to a more granular `interactionMode` prop that supports three distinct interaction levels: "full", "selectable", and "none".

## Key Changes
- **Replaced `readonly` prop with `interactionMode`**: The new prop accepts three values:
  - `"full"`: All interactions enabled (click, drag, selection rect, tools) - default behavior
  - `"selectable"`: Click/select actors but no dragging - used in player mode
  - `"none"`: No actor interaction; only recording handles remain interactive
  
- **Updated StageContainer**: 
  - Recording playback now uses `interactionMode="none"` to disable all actor interactions
  - Main stage uses `interactionMode="selectable"` when readonly, `"full"` otherwise
  
- **Updated Stage component logic**:
  - `onMouseDown` now checks for `interactionMode === "none"` to prevent interactions
  - Actor dragging only allowed when `interactionMode === "full"`
  - Actor selection, double-click, and mouse events conditionally bound based on `interactive` flag
  - Added comprehensive JSDoc comment explaining the three interaction modes

## Implementation Details
The refactor maintains backward compatibility by defaulting to `"full"` mode while providing more precise control over user interactions in different contexts (recording playback vs. editor vs. player).

https://claude.ai/code/session_01XaKvtP914JnhA7RAHCT2S4