### PR TITLE
Refactor stage addition UI from button to inline card

### DIFF
--- a/frontend/src/editor/components/modal-stages/container.tsx
+++ b/frontend/src/editor/components/modal-stages/container.tsx
@@ -92,11 +92,14 @@ export const StagesContainer = () => {
                 <h3>{s.name || "Untitled"}</h3>
               </div>
             ))}
+            <div className="stage-item add-stage" onClick={_onAddStage}>
+              <div className="add-stage-placeholder">
+                <i className="fa fa-plus" />
+              </div>
+              <h3>Add Stage</h3>
+            </div>
           </div>
           <div className="bar">
-            <Button className="add" onClick={_onAddStage}>
-              <i className="fa fa-plus" />
-            </Button>
             <Button className="remove" disabled={stagesArray.length <= 1} onClick={_onRemoveStage}>
               <i className="fa fa-minus" />
             </Button>

--- a/frontend/src/editor/components/toolbar.tsx
+++ b/frontend/src/editor/components/toolbar.tsx
@@ -12,7 +12,6 @@ import DropdownToggle from "reactstrap/lib/DropdownToggle";
 import * as actions from "../actions/ui-actions";
 import { updateWorldMetadata } from "../actions/world-actions";
 import { MODALS, TOOLS } from "../constants/constants";
-import { getCurrentStage } from "../utils/selectors";
 import { TapToEditLabel } from "./tap-to-edit-label";
 import UndoRedoControls from "./undo-redo-controls";
 
@@ -23,7 +22,6 @@ import { useEditorSelector } from "../../hooks/redux";
 const Toolbar = () => {
   const dispatch = useDispatch();
   const selectedToolId = useEditorSelector((state) => state.ui.selectedToolId);
-  const stageName = useEditorSelector((state) => getCurrentStage(state)?.name);
   const metadata = useEditorSelector((state) => state.world.metadata);
   const isInTutorial = useEditorSelector((state) => state.ui.tutorial.stepIndex === 0);
 
@@ -167,7 +165,7 @@ const Toolbar = () => {
           className="dropdown-toggle"
         >
           <img src={new URL("../img/sidebar_choose_background.png", import.meta.url).href} />
-          <span className="title">{stageName || "Untitled Stage"}</span>
+          <span className="title">Stage Settings</span>
         </Button>
       </div>
     </div>

--- a/frontend/src/editor/styles/editor.scss
+++ b/frontend/src/editor/styles/editor.scss
@@ -1267,7 +1267,6 @@ button.btn.selected:active {
   .bar {
     display: flex;
 
-    .add,
     .remove {
       width: 28px;
       height: 28px;
@@ -1293,9 +1292,35 @@ button.btn.selected:active {
       background-color: gray;
       vertical-align: top;
       padding: 2px;
+      cursor: pointer;
       &.selected {
         border: 2px solid color.adjust($tint-color, $lightness: 10%);
         background-color: $tint-color;
+      }
+      &.add-stage {
+        background-color: transparent;
+        border: 2px dashed #aaa;
+        &:hover {
+          border-color: $tint-color;
+          .add-stage-placeholder {
+            color: $tint-color;
+          }
+          h3 {
+            color: $tint-color;
+          }
+        }
+        .add-stage-placeholder {
+          width: 160px;
+          height: 104px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          color: #aaa;
+          font-size: 32px;
+        }
+        h3 {
+          color: #aaa;
+        }
       }
       img {
         width: 160px;

--- a/frontend/src/editor/styles/editor.scss
+++ b/frontend/src/editor/styles/editor.scss
@@ -1312,6 +1312,7 @@ button.btn.selected:active {
         .add-stage-placeholder {
           width: 160px;
           height: 104px;
+          box-sizing: content-box;
           display: flex;
           align-items: center;
           justify-content: center;


### PR DESCRIPTION
## Summary
Refactored the "Add Stage" functionality from a separate button in the control bar to an inline card within the stages list, improving the visual hierarchy and user experience of the stage management interface.

## Key Changes
- **Moved "Add Stage" button to stages list**: Converted the `.add` button in the control bar to an inline `.add-stage` card that appears at the end of the stages list
- **Updated styling**: 
  - Removed `.add` button styles from the control bar
  - Added new `.add-stage` card styles with transparent background, dashed border, and hover effects
  - Added `cursor: pointer` to stage items for better UX
  - Styled the placeholder icon and "Add Stage" label with color transitions on hover
- **Simplified toolbar**: Changed the stage dropdown label from dynamic stage name to static "Stage Settings" text and removed the unused `getCurrentStage` selector
- **Removed unused import**: Cleaned up the `getCurrentStage` import from toolbar.tsx

## Implementation Details
- The new `.add-stage` card uses a dashed border (`#aaa`) that transitions to the tint color on hover
- The placeholder icon and heading text also change color on hover for visual feedback
- The card maintains the same dimensions as regular stage items (160px × 104px) for consistent layout
- The control bar now only contains the "Remove" button, with "Add Stage" integrated into the main stages list

https://claude.ai/code/session_01EkGy9U8oK2L6N9z6PJDWBi