### PR TITLE
Ensure initial frame is always returned from frame accumulator

### DIFF
--- a/frontend/src/editor/utils/frame-accumulator.ts
+++ b/frontend/src/editor/utils/frame-accumulator.ts
@@ -54,6 +54,13 @@ export class FrameAccumulator {
       current.id = this.initial.id + frameIndex;
       frameIndex++;
     }
+
+    // Always return at least the initial frame so that the tick clock
+    // receives a new unique tickKey on every tick, even when no rules fire.
+    if (frames.length === 0) {
+      frames.push(this.initial);
+    }
+
     return frames;
   }
 }


### PR DESCRIPTION
## Summary
Modified the `FrameAccumulator` to always return at least the initial frame, even when no animation rules fire during a tick cycle.

## Key Changes
- Added a check in the `getFrames()` method to push the initial frame to the frames array if it's empty
- This ensures the tick clock receives a new unique `tickKey` on every tick, maintaining consistent timing behavior regardless of whether any rules are triggered

## Implementation Details
The change is minimal and defensive: after the frame accumulation loop completes, if no frames were generated (meaning no rules fired), the initial frame is added to the result set. This prevents the accumulator from returning an empty array and ensures the animation system continues to tick properly even during periods of inactivity.

https://claude.ai/code/session_01XMzx1X9kfSdznECBDXPSwZ