### PR TITLE
Fix save logic to chain full save after in-flight draft save

### DIFF
--- a/frontend/src/components/editor-page.tsx
+++ b/frontend/src/components/editor-page.tsx
@@ -298,7 +298,8 @@ const EditorPage = () => {
       _saveTimeout.current = null;
     }
     if (_savePromise.current) {
-      return _savePromise.current;
+      // Wait for in-flight save (e.g. draft) to complete, then perform the full save
+      return _savePromise.current.then(() => save());
     }
 
     _isCommitting.current = true; // Prevent auto-save during commit


### PR DESCRIPTION
## Summary
Fixed a bug in the editor's save logic where an in-flight save operation would prevent a subsequent full save from executing.

## Key Changes
- Modified the save handler to chain a full save operation after any in-flight save completes, rather than returning the in-flight promise directly
- Added clarifying comment explaining that the full save should execute after draft saves complete

## Implementation Details
When a save is triggered while another save is already in progress, the code now waits for the in-flight operation to complete and then executes the full save operation. Previously, it would simply return the in-flight promise, which could result in the full save being skipped if the in-flight operation was a draft save.

This ensures that user-initiated saves are not lost when they occur during auto-save operations.

https://claude.ai/code/session_01KiXH2xbAxt7V972AaohGDe