### PR TITLE
Fix actor selection to use clicked position instead of actor position

### DIFF
--- a/frontend/src/editor/components/stage/stage.tsx
+++ b/frontend/src/editor/components/stage/stage.tsx
@@ -683,8 +683,9 @@ export const Stage = ({
     let handled = false;
 
     // Helper to check for overlapping actors and show popover if needed
+    const clickedPosition = getPositionForEvent(event);
     const showPopoverIfOverlapping = (toolId: string): boolean => {
-      const overlapping = actorsAtPoint(stage.actors, characters, actor.position, characterZOrder);
+      const overlapping = actorsAtPoint(stage.actors, characters, clickedPosition, characterZOrder);
       if (overlapping.length > 1) {
         setActorSelectionPopover({
           actors: overlapping,
@@ -749,7 +750,7 @@ export const Stage = ({
             ),
           );
         } else {
-          const overlapping = actorsAtPoint(stage.actors, characters, actor.position, characterZOrder);
+          const overlapping = actorsAtPoint(stage.actors, characters, clickedPosition, characterZOrder);
           const topActor = overlapping[overlapping.length - 1];
           const isTopActorSelected = topActor && selected.some((a) => a.id === topActor.id);
 


### PR DESCRIPTION
## Summary
Fixed a bug in the Stage component where actor overlap detection was using the wrong position reference, causing incorrect actor selection behavior when clicking on the stage.

## Key Changes
- Extracted the clicked position from the event at the beginning of the click handler using `getPositionForEvent(event)`
- Updated two `actorsAtPoint()` calls to use the clicked position (`clickedPosition`) instead of `actor.position`
- This ensures overlap detection is based on where the user actually clicked, not on a potentially stale actor position

## Implementation Details
The fix addresses a logic error where the overlap detection for actor selection was referencing `actor.position` instead of the actual position where the click event occurred. By capturing `clickedPosition` once at the start of the handler and reusing it in both overlap detection calls, the code now correctly identifies which actors are at the clicked location, improving the accuracy of the actor selection popover and selection behavior.

https://claude.ai/code/session_01FqbiWba4SJvqhACH9UaUyr