### PR TITLE
Hide reCAPTCHA badge on editor and play pages

### DIFF
--- a/frontend/src/components/editor-page.tsx
+++ b/frontend/src/components/editor-page.tsx
@@ -7,6 +7,7 @@ import RootEditor from "../editor/root-editor";
 import StoreProvider from "../editor/store-provider";
 import { deepClone } from "../editor/utils/utils";
 import { makeRequest } from "../helpers/api";
+import { useHideRecaptchaBadge } from "../hooks/useHideRecaptchaBadge";
 import { usePageTitle } from "../hooks/usePageTitle";
 
 import { useParams } from "react-router";
@@ -201,6 +202,7 @@ const EditorPage = () => {
   }, [hasUnsavedChanges]);
 
   usePageTitle(world?.name);
+  useHideRecaptchaBadge();
 
   useEffect(() => {
     const load = async () => {

--- a/frontend/src/components/play-page.tsx
+++ b/frontend/src/components/play-page.tsx
@@ -4,6 +4,7 @@ import { Link, useParams } from "react-router-dom";
 import Button from "reactstrap/lib/Button";
 
 import { createWorld, fetchWorld } from "../actions/main-actions";
+import { useHideRecaptchaBadge } from "../hooks/useHideRecaptchaBadge";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { RootPlayer } from "../editor/root-player";
 import PageMessage from "./common/page-message";
@@ -34,6 +35,7 @@ const PlayPage: React.FC = () => {
   }, [worldId, dispatch]);
 
   usePageTitle(world?.name);
+  useHideRecaptchaBadge();
 
   // Listen for fullscreen changes
   useEffect(() => {

--- a/frontend/src/hooks/useHideRecaptchaBadge.ts
+++ b/frontend/src/hooks/useHideRecaptchaBadge.ts
@@ -1,0 +1,20 @@
+import { useEffect } from "react";
+
+/**
+ * Hides the Google reCAPTCHA v3 badge while the component is mounted.
+ * The badge reappears when the component unmounts.
+ */
+export function useHideRecaptchaBadge() {
+  useEffect(() => {
+    const badge = document.querySelector<HTMLElement>(".grecaptcha-badge");
+    if (badge) {
+      badge.style.visibility = "hidden";
+    }
+    return () => {
+      const badge = document.querySelector<HTMLElement>(".grecaptcha-badge");
+      if (badge) {
+        badge.style.visibility = "visible";
+      }
+    };
+  }, []);
+}


### PR DESCRIPTION
## Summary
This PR hides the Google reCAPTCHA v3 badge while users are on the editor and play pages, improving the visual experience by removing the persistent badge from these content-focused views.

## Changes
- **New hook**: Created `useHideRecaptchaBadge()` hook that manages the visibility of the reCAPTCHA badge
  - Hides the badge when the component mounts
  - Restores badge visibility when the component unmounts
  - Uses a cleanup function to ensure proper state restoration
  
- **Applied to pages**: Integrated the hook into:
  - `EditorPage` component
  - `PlayPage` component

## Implementation Details
- The hook queries the DOM for the `.grecaptcha-badge` element and toggles its `visibility` CSS property
- Uses an empty dependency array to run only once on mount
- The cleanup function ensures the badge is restored if the user navigates away, maintaining proper reCAPTCHA functionality on other pages

https://claude.ai/code/session_019DRSCUu1MrbinH1qS71qFj