### PR TITLE
Refactor character creation button to standalone component

### DIFF
--- a/frontend/src/editor/components/library.tsx
+++ b/frontend/src/editor/components/library.tsx
@@ -298,19 +298,24 @@ export const Library: React.FC = () => {
           <ButtonDropdown
             size="sm"
             isOpen={characterDropdownOpen}
-            data-tutorial-id="characters-add-button"
             toggle={toggleCharacterDropdown}
           >
             <DropdownToggle caret>
-              <i className="fa fa-plus" />
+              More
             </DropdownToggle>
             <DropdownMenu right>
-              <DropdownItem onClick={onCreateCharacter}>Draw new Character...</DropdownItem>
               <DropdownItem onClick={onExploreCharacters}>Explore Characters...</DropdownItem>
               <DropdownItem divider />
               <DropdownItem onClick={onSetCharacterOrder}>Set Character Order...</DropdownItem>
             </DropdownMenu>
           </ButtonDropdown>
+          <Button
+            size="sm"
+            data-tutorial-id="characters-add-button"
+            onClick={onCreateCharacter}
+          >
+            <i className="fa fa-plus" />
+          </Button>
         </div>
         {renderCharactersPanel()}
       </div>

--- a/frontend/src/editor/styles/editor.scss
+++ b/frontend/src/editor/styles/editor.scss
@@ -678,6 +678,7 @@ html {
       .header {
         display: flex;
         flex-shrink: 0;
+        gap: 4px;
         h2 {
           flex: 1;
         }


### PR DESCRIPTION
## Summary
Refactored the character creation button from a dropdown menu item to a standalone primary button in the library header, improving discoverability and UX for the most common action.

## Key Changes
- Moved "Draw new Character" action from the character dropdown menu to a dedicated button with a plus icon
- Renamed dropdown toggle label from icon-only to "More" for clarity
- Removed `data-tutorial-id` from dropdown and applied it to the new standalone button
- Added 4px gap spacing in the header flex layout to properly space the new button alongside the dropdown

## Implementation Details
- The new button maintains the same `onClick={onCreateCharacter}` handler and styling (`size="sm"`)
- The dropdown menu now contains only secondary actions: "Explore Characters" and "Set Character Order"
- CSS gap property ensures consistent spacing between the primary action button and the "More" dropdown

https://claude.ai/code/session_01N2UbnHKLvUTG1TzJggFmnB