### PR TITLE
Change keypicker default comparator from "contains" to "="

### DIFF
--- a/frontend/src/editor/components/modal-keypicker/container.tsx
+++ b/frontend/src/editor/components/modal-keypicker/container.tsx
@@ -41,7 +41,7 @@ export const KeypickerContainer = () => {
         key: replaceConditionKey || makeId("condition"),
         enabled: true,
         left: { globalId: "keypress" },
-        comparator: "contains",
+        comparator: "=",
         right: { constant: key },
       }),
     );


### PR DESCRIPTION
## Summary
Updated the default comparator used when creating a new condition in the keypicker modal from "contains" to "=" (exact match).

## Changes
- Modified the default comparator value in the condition object created by KeypickerContainer from `"contains"` to `"="` for keypress conditions

## Details
This change affects the behavior when users create a new key condition through the keypicker. Previously, the condition would use a "contains" comparator, which performs substring matching. With this change, it now uses the "=" comparator for exact matching of keypresses, which is more appropriate for key event handling where you typically want to match specific keys exactly rather than check if a key contains a substring.

https://claude.ai/code/session_011TLnFUNx1V1H8BcuYZpsMv