### PR TITLE
Fix selection box z-index layering in stage editor

### DIFF
--- a/frontend/src/editor/components/stage/stage.tsx
+++ b/frontend/src/editor/components/stage/stage.tsx
@@ -1148,6 +1148,7 @@ export const Stage = ({
           className="stage-selection-box"
           style={{
             position: "absolute",
+            zIndex: 1,
             left: Math.min(selectionRect.start.left, selectionRect.end.left),
             top: Math.min(selectionRect.start.top, selectionRect.end.top),
             width:


### PR DESCRIPTION
## Summary
Added explicit z-index styling to the stage selection box to ensure proper layering and visibility during selection operations.

## Changes
- Added `zIndex: 1` to the selection box style object to prevent it from being obscured by other elements on the stage

## Details
The selection box is a temporary visual indicator that appears when users make selections on the stage. By setting an explicit z-index value, we ensure it renders above other stage elements and remains visible to the user during the selection interaction.

https://claude.ai/code/session_01Dj77DDczoQbxc4cMbZdWuu