### PR TITLE
Reorder stage controls: move TickClock after Forward button

### DIFF
--- a/frontend/src/editor/components/stage/stage-controls.tsx
+++ b/frontend/src/editor/components/stage/stage-controls.tsx
@@ -149,16 +149,16 @@ const StageControls: React.FC<StageControlsProps> = ({
         >
           <i className="fa fa-play" /> Play
         </Button>{" "}
-        <TickClock
-          running={running}
-          speed={speed}
-          tickKey={world.evaluatedTickFrames?.[0]?.id}
-        />{" "}
         {!readonly && (
           <Button size="sm" onClick={() => dispatch(advanceGameState(world.id))}>
             <i className="fa fa-step-forward" /> Forward
           </Button>
-        )}
+        )}{" "}
+        <TickClock
+          running={running}
+          speed={speed}
+          tickKey={world.evaluatedTickFrames?.[0]?.id}
+        />
       </div>
 
       <div style={{ flex: 1 }} />


### PR DESCRIPTION
## Summary
Reorganized the layout of stage control buttons by moving the TickClock component to appear after the Forward button instead of before it.

## Key Changes
- Moved `TickClock` component from before the conditional Forward button to after it
- Adjusted spacing: removed trailing space from `TickClock` opening tag and added trailing space after the Forward button conditional block to maintain consistent spacing between controls

## Implementation Details
This change affects the visual order of controls in the stage editor without modifying any functional behavior. The TickClock component now renders after the Forward button, improving the logical flow of the playback controls UI.

https://claude.ai/code/session_01G2jbvd2Pv27MMA73ThQwYx