### PR TITLE
Add drag-to-reorder support in actor disambiguation popover

### DIFF
--- a/frontend/src/editor/components/stage/actor-selection-popover.tsx
+++ b/frontend/src/editor/components/stage/actor-selection-popover.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { Actor, Characters } from "../../../types";
 import { STAGE_CELL_SIZE } from "../../constants/constants";
 import { getTransformedBounds } from "../../utils/stage-helpers";
@@ -8,9 +8,11 @@ import { DEFAULT_APPEARANCE_INFO } from "../sprites/sprite";
 interface ActorSelectionPopoverProps {
   actors: Actor[];
   characters: Characters;
+  characterZOrder: string[];
   position: { x: number; y: number }; // Screen pixel position for popover
   onSelect: (actor: Actor) => void;
   onClose: () => void;
+  onReorder?: (newCharacterZOrder: string[]) => void;
   onStartDrag?: (
     actor: Actor,
     actorIds: string[],
@@ -22,12 +24,35 @@ interface ActorSelectionPopoverProps {
 const ActorSelectionPopover: React.FC<ActorSelectionPopoverProps> = ({
   actors,
   characters,
+  characterZOrder,
   position,
   onSelect,
   onClose,
+  onReorder,
   onStartDrag,
 }) => {
   const popoverRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  // Display order: top = highest z (reversed from the z-order array)
+  const [orderedActors, setOrderedActors] = useState<Actor[]>(() => [...actors].reverse());
+  const [reorder, setReorder] = useState<{ dragIndex: number; dropIndex: number } | null>(null);
+
+  // Refs for accessing latest values in mouse-event handlers
+  const orderedActorsRef = useRef(orderedActors);
+  orderedActorsRef.current = orderedActors;
+  const characterZOrderRef = useRef(characterZOrder);
+  characterZOrderRef.current = characterZOrder;
+  const onReorderRef = useRef(onReorder);
+  onReorderRef.current = onReorder;
+  const reorderRef = useRef(reorder);
+  reorderRef.current = reorder;
+
+  useEffect(() => {
+    const newOrder = [...actors].reverse();
+    setOrderedActors(newOrder);
+    orderedActorsRef.current = newOrder;
+  }, [actors]);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -55,6 +80,85 @@ const ActorSelectionPopover: React.FC<ActorSelectionPopoverProps> = ({
     };
   }, [onClose]);
 
+  const applyReorder = useCallback((dragIdx: number, dropIdx: number) => {
+    const current = orderedActorsRef.current;
+    const next = [...current];
+    const [moved] = next.splice(dragIdx, 1);
+    const insertAt = dropIdx > dragIdx ? dropIdx - 1 : dropIdx;
+    next.splice(insertAt, 0, moved);
+    setOrderedActors(next);
+    orderedActorsRef.current = next;
+
+    const cb = onReorderRef.current;
+    if (!cb) return;
+
+    // Compute new characterZOrder from the new visual order.
+    // Visual order is top-to-bottom = highest-z first. The characterZOrder
+    // array stores lowest-z first, so we reverse the unique character list.
+    const czOrder = characterZOrderRef.current;
+    const seen = new Set<string>();
+    const uniqueVisual: string[] = [];
+    for (const actor of next) {
+      if (!seen.has(actor.characterId)) {
+        seen.add(actor.characterId);
+        uniqueVisual.push(actor.characterId);
+      }
+    }
+    const reorderedChars = [...uniqueVisual].reverse();
+    const slots = reorderedChars
+      .map((id) => czOrder.indexOf(id))
+      .filter((i) => i >= 0)
+      .sort((a, b) => a - b);
+
+    const result = [...czOrder];
+    for (let i = 0; i < slots.length && i < reorderedChars.length; i++) {
+      result[slots[i]] = reorderedChars[i];
+    }
+    cb(result);
+  }, []);
+
+  const onHandleMouseDown = useCallback(
+    (event: React.MouseEvent, index: number) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      const state = { dragIndex: index, dropIndex: index };
+      reorderRef.current = state;
+      setReorder({ ...state });
+
+      const onMouseMove = (e: MouseEvent) => {
+        if (!listRef.current || !reorderRef.current) return;
+        const items = Array.from(listRef.current.querySelectorAll(".actor-option"));
+        let newDropIndex = items.length;
+        for (let i = 0; i < items.length; i++) {
+          const rect = items[i].getBoundingClientRect();
+          if (e.clientY < rect.top + rect.height / 2) {
+            newDropIndex = i;
+            break;
+          }
+        }
+        reorderRef.current.dropIndex = newDropIndex;
+        setReorder({ ...reorderRef.current });
+      };
+
+      const onMouseUp = () => {
+        document.removeEventListener("mousemove", onMouseMove);
+        document.removeEventListener("mouseup", onMouseUp);
+
+        const s = reorderRef.current;
+        if (s && s.dragIndex !== s.dropIndex) {
+          applyReorder(s.dragIndex, s.dropIndex);
+        }
+        reorderRef.current = null;
+        setReorder(null);
+      };
+
+      document.addEventListener("mousemove", onMouseMove);
+      document.addEventListener("mouseup", onMouseUp);
+    },
+    [applyReorder],
+  );
+
   // Calculate popover position, keeping it on screen
   const popoverStyle: React.CSSProperties = {
     position: "fixed",
@@ -65,8 +169,8 @@ const ActorSelectionPopover: React.FC<ActorSelectionPopoverProps> = ({
 
   return (
     <div ref={popoverRef} className="actor-selection-popover" style={popoverStyle}>
-      <div className="actor-selection-popover-content">
-        {[...actors].reverse().map((actor) => {
+      <div className="actor-selection-popover-content" ref={listRef}>
+        {orderedActors.map((actor, index) => {
           const character = characters[actor.characterId];
           const { appearanceInfo } = character.spritesheet;
           const info = appearanceInfo?.[actor.appearance] || DEFAULT_APPEARANCE_INFO;
@@ -76,18 +180,38 @@ const ActorSelectionPopover: React.FC<ActorSelectionPopoverProps> = ({
           // Calculate transformed bounds to properly size container and position sprite
           const bounds = getTransformedBounds(info, actor.transform);
 
+          const isDragging = reorder?.dragIndex === index;
+          const showDropAbove =
+            reorder !== null &&
+            reorder.dropIndex === index &&
+            reorder.dragIndex !== index &&
+            reorder.dragIndex !== index - 1;
+
           return (
             <div
               key={actor.id}
-              className="actor-option"
+              className={`actor-option${isDragging ? " reorder-dragging" : ""}${showDropAbove ? " reorder-drop-above" : ""}`}
               style={{
-                width: bounds.width * STAGE_CELL_SIZE + 8,
-                height: bounds.height * STAGE_CELL_SIZE + 8,
                 padding: 2,
                 overflow: "hidden",
               }}
             >
-              <div style={{ position: "relative" }}>
+              {onReorder && (
+                <span
+                  className="reorder-handle"
+                  onMouseDown={(e) => onHandleMouseDown(e, index)}
+                >
+                  &#x2630;
+                </span>
+              )}
+              <div
+                style={{
+                  position: "relative",
+                  width: bounds.width * STAGE_CELL_SIZE + 4,
+                  height: bounds.height * STAGE_CELL_SIZE + 4,
+                  flexShrink: 0,
+                }}
+              >
                 <ActorSprite
                   character={character}
                   actor={{ ...actor, position: { x: bounds.offsetX, y: bounds.offsetY } }}
@@ -109,6 +233,11 @@ const ActorSelectionPopover: React.FC<ActorSelectionPopoverProps> = ({
             </div>
           );
         })}
+        {reorder !== null &&
+          reorder.dropIndex === orderedActors.length &&
+          reorder.dragIndex !== orderedActors.length - 1 && (
+            <div className="reorder-drop-indicator" />
+          )}
       </div>
     </div>
   );

--- a/frontend/src/editor/components/stage/stage.tsx
+++ b/frontend/src/editor/components/stage/stage.tsx
@@ -29,6 +29,7 @@ import {
   selectToolId,
   selectToolItem,
 } from "../../actions/ui-actions";
+import { setCharacterZOrder } from "../../actions/characters-actions";
 
 import { STAGE_CELL_SIZE, TOOLS } from "../../constants/constants";
 import { extentIgnoredPositions } from "../../utils/recording-helpers";
@@ -973,6 +974,10 @@ export const Stage = ({
     setActorSelectionPopover(null);
   };
 
+  const onPopoverReorder = (newZOrder: string[]) => {
+    dispatch(setCharacterZOrder(newZOrder));
+  };
+
   const renderRecordingExtent = () => {
     const { width, height } = stage;
     if (!recordingExtent) {
@@ -1168,9 +1173,11 @@ export const Stage = ({
         <ActorSelectionPopover
           actors={actorSelectionPopover.actors}
           characters={characters}
+          characterZOrder={characterZOrder}
           position={actorSelectionPopover.position}
           onSelect={onPopoverSelectActor}
           onClose={onPopoverClose}
+          onReorder={onPopoverReorder}
           onStartDrag={
             actorSelectionPopover.toolId === TOOLS.POINTER ? onStartSpriteDrag : undefined
           }

--- a/frontend/src/editor/styles/editor.scss
+++ b/frontend/src/editor/styles/editor.scss
@@ -958,6 +958,8 @@ html {
 
   .actor-option {
     cursor: pointer;
+    display: flex;
+    align-items: center;
     border: 2px solid transparent;
     border-radius: 4px;
     background: #f5f5f5;
@@ -970,9 +972,36 @@ html {
       background: rgba(0, 123, 255, 0.1);
     }
 
+    &.reorder-dragging {
+      opacity: 0.4;
+    }
+
+    &.reorder-drop-above {
+      border-top: 2px solid #007bff;
+    }
+
     img {
       pointer-events: auto;
     }
+
+    .reorder-handle {
+      color: #999;
+      font-size: 12px;
+      padding: 0 4px;
+      cursor: grab;
+      user-select: none;
+      flex-shrink: 0;
+
+      &:hover {
+        color: #555;
+      }
+    }
+  }
+
+  .reorder-drop-indicator {
+    height: 2px;
+    background: #007bff;
+    margin-top: 2px;
   }
 }
 


### PR DESCRIPTION
When multiple actors overlap on a stage square, the disambiguation popover now shows a drag handle on each item. Dragging the handle reorders actors within the popover and immediately updates the global characterZOrder, matching the behavior of the Set Character Order modal but inline for quick adjustments.

https://claude.ai/code/session_01WC2SDaEsQAnv8zNwU2hm77