### PR TITLE
Standardize add button icons to use plus icon

### DIFF
--- a/frontend/src/editor/components/inspector/add-rule-button.tsx
+++ b/frontend/src/editor/components/inspector/add-rule-button.tsx
@@ -50,7 +50,7 @@ const RuleAddButton = ({
       toggle={() => setOpen(!open)}
     >
       <DropdownToggle caret disabled={!character || isRecording}>
-        <i className="fa fa-tasks" /> Add
+        <i className="fa fa-plus" />
       </DropdownToggle>
       <DropdownMenu right>
         <DropdownItem onClick={_onCreateRule}>

--- a/frontend/src/editor/components/inspector/add-variable-button.tsx
+++ b/frontend/src/editor/components/inspector/add-variable-button.tsx
@@ -27,7 +27,7 @@ const VariablesAddButton = ({ character }: { character: Character; actor: Actor 
       toggle={() => setOpen(!open)}
     >
       <DropdownToggle caret>
-        <i className="fa fa-inbox" /> Add
+        <i className="fa fa-plus" />
       </DropdownToggle>
       <DropdownMenu right>
         <DropdownItem disabled={!character} onClick={_onCreateVar}>


### PR DESCRIPTION
## Summary
Updated the icon and label styling for the "Add Rule" and "Add Variable" buttons in the inspector to use a consistent plus icon across the UI.

## Changes
- **Add Rule Button**: Changed icon from `fa-tasks` to `fa-plus` and removed the "Add" text label
- **Add Variable Button**: Changed icon from `fa-inbox` to `fa-plus` and removed the "Add" text label

## Details
Both buttons now use the same `fa-plus` icon for visual consistency, relying on the icon alone to convey the add action rather than combining an icon with text. This creates a more uniform and streamlined appearance across the inspector interface.

https://claude.ai/code/session_01HcNNUQbh3h5h3jXCUX5e5b