### PR TITLE
Remove globals configuration from Vitest setup

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -17,7 +17,4 @@ export default defineConfig({
   server: {
     open: true,
   },
-  test: {
-    globals: true,
-  },
 });


### PR DESCRIPTION
## Summary
Removed the `globals: true` configuration from the Vitest test setup in the Vite configuration file.

## Changes
- Removed the `test` configuration block from `vite.config.ts` that was enabling global test utilities

## Details
This change removes the Vitest globals configuration, which means test utilities (such as `describe`, `it`, `expect`, etc.) will no longer be automatically available globally in test files. Tests will need to explicitly import these utilities from Vitest if they are used.

https://claude.ai/code/session_01AAzGQ7qdDuDH8uzSUgeerx