### PR TITLE
Add password reset functionality

### DIFF
--- a/api/src/connectors/email.ts
+++ b/api/src/connectors/email.ts
@@ -106,6 +106,13 @@ export async function sendTemplateEmail(
   });
 }
 
+export async function sendPasswordResetEmail(
+  recipient: User,
+  resetUrl: string,
+): Promise<boolean> {
+  return sendTemplateEmail(recipient, "password-reset", "Reset your Codako password", { resetUrl });
+}
+
 export interface ForkEmailData {
   forkerUsername: string;
   worldName: string;

--- a/api/src/connectors/templates/password-reset.html
+++ b/api/src/connectors/templates/password-reset.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Reset your password</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      line-height: 1.6;
+      color: #333;
+      max-width: 600px;
+      margin: 0 auto;
+      padding: 20px;
+    }
+    .header {
+      text-align: center;
+      padding: 20px 0;
+      border-bottom: 1px solid #eee;
+    }
+    .header h1 {
+      color: #5c6bc0;
+      margin: 0;
+      font-size: 24px;
+    }
+    .content {
+      padding: 30px 0;
+    }
+    .button {
+      display: inline-block;
+      background-color: #5c6bc0;
+      color: white;
+      text-decoration: none;
+      padding: 12px 24px;
+      border-radius: 4px;
+      margin: 20px 0;
+    }
+    .footer {
+      text-align: center;
+      padding: 20px 0;
+      border-top: 1px solid #eee;
+      color: #888;
+      font-size: 12px;
+    }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <h1>Codako</h1>
+  </div>
+  <div class="content">
+    <p>Hi {{recipientUsername}},</p>
+    <p>We received a request to reset the password for your Codako account.</p>
+    <p>Click the button below to choose a new password. This link will expire in 1 hour.</p>
+    <p>
+      <a href="{{resetUrl}}" class="button">Reset Your Password</a>
+    </p>
+    <p>If you didn't request a password reset, you can safely ignore this email. Your password will not be changed.</p>
+  </div>
+  <div class="footer">
+    <p>If the button above doesn't work, copy and paste this link into your browser:</p>
+    <p>{{resetUrl}}</p>
+    <p>&copy; Codako</p>
+  </div>
+</body>
+</html>

--- a/api/src/db/entity/user.ts
+++ b/api/src/db/entity/user.ts
@@ -41,6 +41,12 @@ export class User {
   @UpdateDateColumn({ type: "timestamp", default: () => "NOW()" })
   updatedAt: Date;
 
+  @Column({ type: "varchar", nullable: true })
+  passwordResetToken: string | null;
+
+  @Column({ type: "timestamp", nullable: true })
+  passwordResetExpiry: Date | null;
+
   @Column({
     type: "jsonb",
     default: DEFAULT_NOTIFICATION_SETTINGS,

--- a/api/src/db/migrations/1741200000000-AddPasswordResetFields.ts
+++ b/api/src/db/migrations/1741200000000-AddPasswordResetFields.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddPasswordResetFields1741200000000 implements MigrationInterface {
+  name = "AddPasswordResetFields1741200000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "users"
+      ADD COLUMN "passwordResetToken" varchar NULL,
+      ADD COLUMN "passwordResetExpiry" timestamp NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "users"
+      DROP COLUMN "passwordResetToken",
+      DROP COLUMN "passwordResetExpiry"
+    `);
+  }
+}

--- a/api/src/middleware.ts
+++ b/api/src/middleware.ts
@@ -22,7 +22,7 @@ export const userFromBasicAuth = async (
     const hash = crypto.createHmac("sha512", user.passwordSalt);
     hash.update(password);
     if (user.passwordHash !== hash.digest("hex")) {
-      return res.status(401).json({ message: `The API key you passed is not active.` });
+      return res.status(401).json({ message: `The password you entered is incorrect.` });
     }
     req.user = user;
   }

--- a/api/src/routes/users.ts
+++ b/api/src/routes/users.ts
@@ -1,9 +1,12 @@
 import express from "express";
 import crypto from "node:crypto";
 import { AppDataSource } from "src/db/data-source";
+import { sendPasswordResetEmail } from "src/connectors/email";
 import { User } from "src/db/entity/user";
 import { userFromBasicAuth } from "src/middleware";
 import { logger } from "src/logger";
+
+const APP_URL = process.env.APP_URL || "https://www.codako.org";
 
 const router = express.Router();
 
@@ -114,6 +117,56 @@ router.post("/users", async (req, res) => {
       res.status(400).json({ message: `${err}` });
     }
   }
+});
+
+router.post("/users/forgot-password", async (req, res) => {
+  const { email } = req.body;
+  if (!email) {
+    return res.status(400).json({ message: "Email is required." });
+  }
+
+  const user = await AppDataSource.getRepository(User).findOneBy({ email: email.toLowerCase() });
+
+  // Always return success to avoid leaking whether an email exists
+  if (!user) {
+    return res.json({ message: "If an account with that email exists, we've sent a password reset link." });
+  }
+
+  const token = crypto.randomBytes(32).toString("hex");
+  const expiry = new Date(Date.now() + 60 * 60 * 1000); // 1 hour
+
+  user.passwordResetToken = token;
+  user.passwordResetExpiry = expiry;
+  await AppDataSource.getRepository(User).save(user);
+
+  const resetUrl = `${APP_URL}/reset-password?token=${token}`;
+  await sendPasswordResetEmail(user, resetUrl);
+
+  res.json({ message: "If an account with that email exists, we've sent a password reset link." });
+});
+
+router.post("/users/reset-password", async (req, res) => {
+  const { token, password } = req.body;
+  if (!token || !password) {
+    return res.status(400).json({ message: "Token and password are required." });
+  }
+
+  const user = await AppDataSource.getRepository(User).findOneBy({ passwordResetToken: token });
+  if (!user || !user.passwordResetExpiry || user.passwordResetExpiry < new Date()) {
+    return res.status(400).json({ message: "This reset link is invalid or has expired." });
+  }
+
+  const passwordSalt = `${Math.round(new Date().valueOf() * Math.random())}`;
+  const hash = crypto.createHmac("sha512", passwordSalt);
+  hash.update(password);
+
+  user.passwordHash = hash.digest("hex");
+  user.passwordSalt = passwordSalt;
+  user.passwordResetToken = null;
+  user.passwordResetExpiry = null;
+  await AppDataSource.getRepository(User).save(user);
+
+  res.json({ message: "Your password has been reset. You can now log in." });
 });
 
 export default router;

--- a/frontend/src/components/forgot-password-page.tsx
+++ b/frontend/src/components/forgot-password-page.tsx
@@ -1,0 +1,97 @@
+import React, { useRef, useState } from "react";
+import { Link } from "react-router-dom";
+import Button from "reactstrap/lib/Button";
+import Col from "reactstrap/lib/Col";
+import Container from "reactstrap/lib/Container";
+import Row from "reactstrap/lib/Row";
+
+import { makeRequest } from "../helpers/api";
+
+const ForgotPasswordPage: React.FC = () => {
+  const emailRef = useRef<HTMLInputElement>(null);
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const onSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    const email = emailRef.current?.value ?? "";
+    if (!email) {
+      setError("Please enter your email address.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      await makeRequest("/users/forgot-password", {
+        method: "POST",
+        json: { email },
+      });
+      setSubmitted(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong. Please try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Container>
+      <Row>
+        <Col lg={{ size: 4, offset: 4 }}>
+          <div style={{ textAlign: "center", marginTop: 60, marginBottom: 30 }}>
+            <h3>Reset your password</h3>
+          </div>
+          <div className="card">
+            {submitted ? (
+              <div className="card-body">
+                <p>
+                  If an account with that email exists, we've sent a password reset link. Please
+                  check your inbox.
+                </p>
+                <Link to="/login">Back to login</Link>
+              </div>
+            ) : (
+              <>
+                {error && (
+                  <div className="card card-inverse bg-danger text-white card-body text-xs-center">
+                    {error}
+                  </div>
+                )}
+                <form className="card-body" onSubmit={onSubmit}>
+                  <div className="form-group">
+                    <label htmlFor="email">
+                      Enter the email address associated with your account and we'll send you a link
+                      to reset your password.
+                    </label>
+                    <input
+                      className="form-control"
+                      id="email"
+                      ref={emailRef}
+                      type="email"
+                      autoFocus
+                      autoComplete="email"
+                      autoCorrect="off"
+                      autoCapitalize="off"
+                    />
+                  </div>
+                  <Button block color="primary" type="submit" disabled={isSubmitting}>
+                    {isSubmitting ? "Sending..." : "Send reset link"}
+                  </Button>
+                </form>
+              </>
+            )}
+          </div>
+          <div className="card" style={{ marginTop: 20 }}>
+            <div className="card-body text-xs-center">
+              <Link to="/login">Back to login</Link>
+            </div>
+          </div>
+        </Col>
+      </Row>
+    </Container>
+  );
+};
+
+export default ForgotPasswordPage;

--- a/frontend/src/components/login-page.tsx
+++ b/frontend/src/components/login-page.tsx
@@ -89,6 +89,9 @@ const LoginPage: React.FC = () => {
               <Button block color="primary" type="submit">
                 Login
               </Button>
+              <div style={{ textAlign: "center", marginTop: 10 }}>
+                <Link to="/forgot-password">Forgot your password?</Link>
+              </div>
             </form>
           </div>
           <div className="card" style={{ marginTop: 20 }}>

--- a/frontend/src/components/reset-password-page.tsx
+++ b/frontend/src/components/reset-password-page.tsx
@@ -1,0 +1,129 @@
+import React, { useMemo, useRef, useState } from "react";
+import { Link, useLocation } from "react-router-dom";
+import Button from "reactstrap/lib/Button";
+import Col from "reactstrap/lib/Col";
+import Container from "reactstrap/lib/Container";
+import Row from "reactstrap/lib/Row";
+
+import { makeRequest } from "../helpers/api";
+
+const ResetPasswordPage: React.FC = () => {
+  const location = useLocation();
+  const search = useMemo(() => new URLSearchParams(location.search), [location.search]);
+  const token = search.get("token");
+
+  const passRef = useRef<HTMLInputElement>(null);
+  const confirmRef = useRef<HTMLInputElement>(null);
+  const [success, setSuccess] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const onSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    const password = passRef.current?.value ?? "";
+    const confirm = confirmRef.current?.value ?? "";
+
+    if (!password) {
+      setError("Please enter a new password.");
+      return;
+    }
+    if (password !== confirm) {
+      setError("Passwords do not match.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      await makeRequest("/users/reset-password", {
+        method: "POST",
+        json: { token, password },
+      });
+      setSuccess(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong. Please try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (!token) {
+    return (
+      <Container>
+        <Row>
+          <Col lg={{ size: 4, offset: 4 }}>
+            <div style={{ textAlign: "center", marginTop: 60, marginBottom: 30 }}>
+              <h3>Invalid reset link</h3>
+            </div>
+            <div className="card">
+              <div className="card-body">
+                <p>This password reset link is invalid. Please request a new one.</p>
+                <Link to="/forgot-password">Request a new link</Link>
+              </div>
+            </div>
+          </Col>
+        </Row>
+      </Container>
+    );
+  }
+
+  return (
+    <Container>
+      <Row>
+        <Col lg={{ size: 4, offset: 4 }}>
+          <div style={{ textAlign: "center", marginTop: 60, marginBottom: 30 }}>
+            <h3>Choose a new password</h3>
+          </div>
+          <div className="card">
+            {success ? (
+              <div className="card-body">
+                <p>Your password has been reset successfully.</p>
+                <Link to="/login">
+                  <Button block color="primary">
+                    Log in
+                  </Button>
+                </Link>
+              </div>
+            ) : (
+              <>
+                {error && (
+                  <div className="card card-inverse bg-danger text-white card-body text-xs-center">
+                    {error}
+                  </div>
+                )}
+                <form className="card-body" onSubmit={onSubmit}>
+                  <div className="form-group">
+                    <label htmlFor="password">New password:</label>
+                    <input
+                      className="form-control"
+                      id="password"
+                      ref={passRef}
+                      type="password"
+                      autoFocus
+                      autoComplete="new-password"
+                    />
+                  </div>
+                  <div className="form-group">
+                    <label htmlFor="confirm-password">Confirm new password:</label>
+                    <input
+                      className="form-control"
+                      id="confirm-password"
+                      ref={confirmRef}
+                      type="password"
+                      autoComplete="new-password"
+                    />
+                  </div>
+                  <Button block color="primary" type="submit" disabled={isSubmitting}>
+                    {isSubmitting ? "Resetting..." : "Reset password"}
+                  </Button>
+                </form>
+              </>
+            )}
+          </div>
+        </Col>
+      </Row>
+    </Container>
+  );
+};
+
+export default ResetPasswordPage;

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -5,6 +5,7 @@ import DashboardPage from "./components/dashboard-page";
 import EditorPage from "./components/editor-page";
 import ExplorePage from "./components/explore-page";
 import FAQPage from "./components/faq-page";
+import ForgotPasswordPage from "./components/forgot-password-page";
 import HomePage from "./components/home-page";
 import JoinPage from "./components/join-page";
 import JoinSendWorldsPage from "./components/join-send-worlds-page";
@@ -12,6 +13,7 @@ import LoginPage from "./components/login-page";
 import NotFoundPage from "./components/not-found-page";
 import PlayPage from "./components/play-page";
 import ProfilePage from "./components/profile-page";
+import ResetPasswordPage from "./components/reset-password-page";
 
 export default (
   <Routes>
@@ -21,6 +23,8 @@ export default (
       <Route path="faq" element={<FAQPage />} />
       <Route path="changelog" element={<ChangelogPage />} />
       <Route path="login" element={<LoginPage />} />
+      <Route path="forgot-password" element={<ForgotPasswordPage />} />
+      <Route path="reset-password" element={<ResetPasswordPage />} />
       <Route path="join" element={<JoinPage />} />
       <Route path="join-send-world" element={<JoinSendWorldsPage />} />
 


### PR DESCRIPTION
## Summary
This PR implements a complete password reset flow for users who have forgotten their passwords. It includes frontend pages for requesting a reset link and setting a new password, backend API endpoints to handle the reset process, email notifications, and database schema updates.

## Key Changes

**Frontend:**
- Added `ForgotPasswordPage` component that allows users to request a password reset link via email
- Added `ResetPasswordPage` component that allows users to set a new password using a token from the reset email
- Added "Forgot your password?" link on the login page
- Updated routes to include the new password reset pages

**Backend:**
- Added two new API endpoints:
  - `POST /users/forgot-password` - Initiates password reset by generating a token and sending an email
  - `POST /users/reset-password` - Completes password reset by validating the token and updating the password
- Added `sendPasswordResetEmail()` function to send password reset emails with HTML template
- Created `password-reset.html` email template with reset link and instructions
- Added database migration to add `passwordResetToken` and `passwordResetExpiry` columns to the users table
- Updated User entity to include the new password reset fields

**Security Considerations:**
- Password reset tokens are single-use and expire after 1 hour
- The forgot-password endpoint returns the same success message whether or not an account exists (prevents email enumeration)
- Tokens are cleared after successful password reset
- Password reset tokens are stored separately from user credentials

## Implementation Details
- Reset tokens are generated using `crypto.randomBytes(32)` for cryptographic security
- Passwords are hashed using HMAC-SHA512 with a random salt, consistent with existing authentication
- The reset URL is constructed using the `APP_URL` environment variable
- Email templates use Handlebars-style variable substitution for dynamic content

https://claude.ai/code/session_01VivSKFLqp5K3RFZ6TV4MwQ