### PR TITLE
Configure AWS region for SES client

### DIFF
--- a/api/src/connectors/email.ts
+++ b/api/src/connectors/email.ts
@@ -7,7 +7,9 @@ import { User } from "src/db/entity/user";
 const FROM_EMAIL = process.env.SES_FROM_EMAIL || "noreply@codako.org";
 const FROM_NAME = process.env.SES_FROM_NAME || "Codako";
 
-const ses = new SESClient({});
+const ses = new SESClient({
+  region: process.env.AWS_REGION || "us-east-1",
+});
 
 const templateCache = new Map<string, HandlebarsTemplateDelegate>();
 


### PR DESCRIPTION
## Summary
Added explicit AWS region configuration to the SES client initialization to ensure proper regional endpoint selection.

## Changes
- Modified SES client instantiation to include region configuration
- Region defaults to `us-east-1` if `AWS_REGION` environment variable is not set
- Allows region to be customized via the `AWS_REGION` environment variable

## Implementation Details
The SES client now reads the `AWS_REGION` environment variable during initialization, falling back to `us-east-1` as the default region. This ensures the client connects to the correct AWS region endpoint and prevents potential issues with implicit region resolution.

https://claude.ai/code/session_01Lk28eMNfj7F9GjsAyNhtAX