### PR TITLE
Add password visibility toggle to password input fields

### DIFF
--- a/frontend/src/components/join-page.tsx
+++ b/frontend/src/components/join-page.tsx
@@ -9,6 +9,7 @@ import Row from "reactstrap/lib/Row";
 import { useLocation } from "react-router";
 import { register } from "../actions/main-actions";
 import { useAppSelector } from "../hooks/redux";
+import PasswordInput from "./password-input";
 
 interface NetworkError extends Error {
   statusCode?: number;
@@ -125,14 +126,13 @@ const JoinPage: React.FC = () => {
               </div>
               <div className="form-group">
                 <label htmlFor="password">Password</label>
-                <input
+                <PasswordInput
                   autoComplete="password"
                   autoCorrect="off"
                   autoCapitalize="off"
                   className="form-control"
                   id="password"
                   ref={passRef}
-                  type="password"
                 />
                 <small className="form-text text-muted">
                   Remember it - don't tell anyone else!

--- a/frontend/src/components/login-page.tsx
+++ b/frontend/src/components/login-page.tsx
@@ -8,6 +8,7 @@ import Row from "reactstrap/lib/Row";
 
 import { login } from "../actions/main-actions";
 import { useAppSelector } from "../hooks/redux";
+import PasswordInput from "./password-input";
 
 const LoginPage: React.FC = () => {
   const usernameRef = useRef<HTMLInputElement>(null);
@@ -78,11 +79,10 @@ const LoginPage: React.FC = () => {
               </div>
               <div className="form-group">
                 <label htmlFor="password">Password:</label>
-                <input
+                <PasswordInput
                   className="form-control"
                   id="password"
                   ref={passRef}
-                  type="password"
                   autoComplete="password"
                 />
               </div>

--- a/frontend/src/components/password-input.tsx
+++ b/frontend/src/components/password-input.tsx
@@ -1,0 +1,37 @@
+import React, { useState, forwardRef } from "react";
+
+const PasswordInput = forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
+  (props, ref) => {
+    const [visible, setVisible] = useState(false);
+
+    return (
+      <div style={{ position: "relative" }}>
+        <input {...props} ref={ref} type={visible ? "text" : "password"} />
+        <button
+          type="button"
+          onClick={() => setVisible((v) => !v)}
+          style={{
+            position: "absolute",
+            right: 8,
+            top: "50%",
+            transform: "translateY(-50%)",
+            background: "none",
+            border: "none",
+            cursor: "pointer",
+            padding: "2px 4px",
+            fontSize: 13,
+            color: "#666",
+          }}
+          tabIndex={-1}
+          aria-label={visible ? "Hide password" : "Show password"}
+        >
+          {visible ? "Hide" : "Show"}
+        </button>
+      </div>
+    );
+  },
+);
+
+PasswordInput.displayName = "PasswordInput";
+
+export default PasswordInput;

--- a/frontend/src/components/reset-password-page.tsx
+++ b/frontend/src/components/reset-password-page.tsx
@@ -6,6 +6,7 @@ import Container from "reactstrap/lib/Container";
 import Row from "reactstrap/lib/Row";
 
 import { makeRequest } from "../helpers/api";
+import PasswordInput from "./password-input";
 
 const ResetPasswordPage: React.FC = () => {
   const location = useLocation();
@@ -94,22 +95,20 @@ const ResetPasswordPage: React.FC = () => {
                 <form className="card-body" onSubmit={onSubmit}>
                   <div className="form-group">
                     <label htmlFor="password">New password:</label>
-                    <input
+                    <PasswordInput
                       className="form-control"
                       id="password"
                       ref={passRef}
-                      type="password"
                       autoFocus
                       autoComplete="new-password"
                     />
                   </div>
                   <div className="form-group">
                     <label htmlFor="confirm-password">Confirm new password:</label>
-                    <input
+                    <PasswordInput
                       className="form-control"
                       id="confirm-password"
                       ref={confirmRef}
-                      type="password"
                       autoComplete="new-password"
                     />
                   </div>


### PR DESCRIPTION
## Summary
This PR introduces a reusable `PasswordInput` component that allows users to toggle password visibility, and applies it across all password input fields in the application (login, registration, and password reset pages).

## Key Changes
- **New Component**: Created `PasswordInput` component (`frontend/src/components/password-input.tsx`)
  - Wraps standard HTML input with password visibility toggle functionality
  - Implements a "Show/Hide" button positioned absolutely within the input container
  - Properly forwards refs and accepts all standard input attributes
  - Includes accessibility features (aria-label, tabIndex={-1})

- **Updated Pages**: Replaced standard password inputs with `PasswordInput` component in:
  - `login-page.tsx` - Password field on login form
  - `join-page.tsx` - Password field on registration form
  - `reset-password-page.tsx` - Both password and confirm password fields on password reset form

## Implementation Details
- The component uses React hooks (`useState`) to manage visibility state
- The toggle button is styled with absolute positioning to overlay the input field
- Button has `type="button"` to prevent form submission and `tabIndex={-1}` to keep it out of tab order
- Component is properly exported with `displayName` for debugging purposes
- All existing input attributes (className, autoComplete, etc.) are preserved through spread operator

https://claude.ai/code/session_01W9djCYtSAcVMtevz9a11oj