### PR TITLE
Style password reset button in email template

### DIFF
--- a/api/src/connectors/templates/password-reset.html
+++ b/api/src/connectors/templates/password-reset.html
@@ -53,7 +53,7 @@
     <p>We received a request to reset the password for your Codako account.</p>
     <p>Click the button below to choose a new password. This link will expire in 1 hour.</p>
     <p>
-      <a href="{{resetUrl}}" class="button">Reset Your Password</a>
+      <a href="{{resetUrl}}" class="button" style="display: inline-block; background-color: #5c6bc0; color: #ffffff; text-decoration: none; padding: 12px 24px; border-radius: 4px;">Reset Your Password</a>
     </p>
     <p>If you didn't request a password reset, you can safely ignore this email. Your password will not be changed.</p>
   </div>


### PR DESCRIPTION
## Summary
Updated the password reset email template to include inline CSS styling for the reset button, improving its visual appearance and consistency.

## Changes
- Added inline CSS styles to the password reset button in the email template:
  - `display: inline-block` - ensures proper button rendering
  - `background-color: #5c6bc0` - applies a blue background color
  - `color: #ffffff` - sets text color to white
  - `text-decoration: none` - removes default link underline
  - `padding: 12px 24px` - adds internal spacing
  - `border-radius: 4px` - applies rounded corners

## Details
The button now has a styled appearance that matches modern email design practices, making it more visually prominent and clickable while maintaining accessibility. The inline styles ensure consistent rendering across different email clients.

https://claude.ai/code/session_01JRt6D6FKrA8ZJCmRRnq4JN