### PR TITLE
Fix transform property default value from null to "0"

### DIFF
--- a/frontend/src/editor/reducers/recording-reducer.ts
+++ b/frontend/src/editor/reducers/recording-reducer.ts
@@ -272,7 +272,7 @@ function buildActionsFromStageActions(
             };
           }
 
-          if ("transform" in values && existing.transform !== values.transform) {
+          if ("transform" in values && (existing.transform ?? "0") !== (values.transform ?? "0")) {
             return {
               type: "transform",
               actorId: actorId,

--- a/frontend/src/editor/utils/stage-helpers.test.ts
+++ b/frontend/src/editor/utils/stage-helpers.test.ts
@@ -766,9 +766,9 @@ describe("stage-helpers", () => {
         expect(getVariableValue(actor, character, "transform", "=")).to.equal("90");
       });
 
-      it("should return null for actor without transform", () => {
+      it("should return '0' for actor without transform", () => {
         const actorNoTransform = { ...actor, transform: undefined };
-        expect(getVariableValue(actorNoTransform, character, "transform", "=")).to.be.null;
+        expect(getVariableValue(actorNoTransform, character, "transform", "=")).to.equal("0");
       });
     });
 

--- a/frontend/src/editor/utils/stage-helpers.ts
+++ b/frontend/src/editor/utils/stage-helpers.ts
@@ -247,7 +247,7 @@ export function getVariableValue(
     return character.spritesheet.appearanceNames[actor.appearance];
   }
   if (id === "transform") {
-    return actor.transform ?? null;
+    return actor.transform ?? "0";
   }
   if (id === "x") {
     return String(actor.position.x);


### PR DESCRIPTION
## Summary
Changed the default value for the `transform` property from `null` to `"0"` when an actor doesn't have a transform value defined. This ensures consistent string-based representation across the codebase.

## Key Changes
- **stage-helpers.ts**: Updated `getVariableValue()` to return `"0"` instead of `null` when `actor.transform` is undefined
- **recording-reducer.ts**: Updated transform comparison logic to normalize undefined values to `"0"` on both sides of the comparison using nullish coalescing operator
- **stage-helpers.test.ts**: Updated corresponding test case to expect `"0"` instead of `null` for actors without a transform property

## Implementation Details
The changes ensure that:
- Transform values are consistently represented as strings throughout the system
- Actors without an explicit transform value default to `"0"` rather than `null`
- Transform change detection in the recording reducer properly handles undefined values by normalizing them before comparison

https://claude.ai/code/session_01C6N57o3s3Qn7vdkQ3n8JXJ