### PR TITLE
Remove duplicate 'Back to login' link from password reset success view

### DIFF
--- a/frontend/src/components/forgot-password-page.tsx
+++ b/frontend/src/components/forgot-password-page.tsx
@@ -50,7 +50,6 @@ const ForgotPasswordPage: React.FC = () => {
                   If an account with that email exists, we've sent a password reset link. Please
                   check your inbox.
                 </p>
-                <Link to="/login">Back to login</Link>
               </div>
             ) : (
               <>


### PR DESCRIPTION
The forgot-password page showed two "Back to login" links after submitting a reset request - one inside the success message card and one in a separate card below. Remove the top copy to eliminate the duplication.

https://claude.ai/code/session_01Guk6xdniSCQHKBeHo6pdGs