### PR TITLE
Sort actors by Z-order in scenario stage rendering

### DIFF
--- a/frontend/src/editor/components/inspector/scenario-stage.tsx
+++ b/frontend/src/editor/components/inspector/scenario-stage.tsx
@@ -6,6 +6,7 @@ import React from "react";
 import { Rule, RuleTreeFlowItemCheck, WorldMinimal } from "../../../types";
 import { extentIgnoredPositions } from "../../utils/recording-helpers";
 import { getCurrentStageForWorld } from "../../utils/selectors";
+import { sortActorsByZOrder } from "../../utils/stage-helpers";
 import RecordingIgnoredSprite from "../sprites/recording-ignored-sprite";
 
 export const ScenarioStage = React.memo(
@@ -20,7 +21,7 @@ export const ScenarioStage = React.memo(
     maxWidth: number;
     maxHeight: number;
   }) => {
-    const { world, characters } = window.editorStore!.getState();
+    const { world, characters, characterZOrder } = window.editorStore!.getState();
 
     const { xmin, xmax, ymin, ymax } = rule.extent;
     const width = (xmax - xmin + 1) * STAGE_CELL_SIZE;
@@ -37,11 +38,12 @@ export const ScenarioStage = React.memo(
     }
     return (
       <div className="scenario-stage" style={{ width, height, zoom }}>
-        {Object.keys(ruleStage.actors).map((id) => (
+        {sortActorsByZOrder(Object.values(ruleStage.actors), characterZOrder).map((actor) => (
           <ActorSprite
-            key={id}
-            character={characters[ruleStage.actors[id].characterId]}
-            actor={ruleStage.actors[id]}
+            key={actor.id}
+            character={characters[actor.characterId]}
+            actor={actor}
+            zIndex={characterZOrder.indexOf(actor.characterId)}
           />
         ))}
         {extentIgnoredPositions(rule.extent).map(({ x, y }) => (


### PR DESCRIPTION
## Summary
Updated the scenario stage component to render actors in the correct Z-order based on character depth ordering, ensuring proper visual layering of actors in the editor.

## Key Changes
- Added import of `sortActorsByZOrder` utility function from stage-helpers
- Retrieved `characterZOrder` from editor store state to determine actor rendering order
- Refactored actor rendering loop to:
  - Sort actors using the new `sortActorsByZOrder` function before mapping
  - Iterate over sorted actor objects directly instead of keys
  - Pass `zIndex` prop to ActorSprite component based on character position in Z-order
- Simplified actor property access by working with actor objects directly rather than looking them up by ID

## Implementation Details
The change ensures actors are rendered in the correct visual order by sorting them according to the `characterZOrder` array before rendering. The `zIndex` is calculated as the index position of each actor's character ID in the Z-order array, which can be used for CSS layering if needed.

https://claude.ai/code/session_01Wnf2JVQQ5NEPvbwGULw34m