### PR TITLE
Convert RecordingHandle from img to div with background image

### DIFF
--- a/frontend/src/editor/components/sprites/recording-handle.tsx
+++ b/frontend/src/editor/components/sprites/recording-handle.tsx
@@ -14,18 +14,20 @@ const RecordingHandle = ({ side, position }: { side: string; position: Position 
   };
 
   return (
-    <img
+    <div
       draggable
       data-stage-handle={side}
       onDragStart={onDragStart}
       className={`handle-${side}`}
-      src={new URL(`../../img/tiles/handle_${side}.png`, import.meta.url).href}
       style={{
         position: "absolute",
         width: STAGE_CELL_SIZE,
         height: STAGE_CELL_SIZE,
         left: position.x * STAGE_CELL_SIZE,
         top: position.y * STAGE_CELL_SIZE,
+        backgroundImage: `url(${new URL(`../../img/tiles/handle_${side}.png`, import.meta.url).href})`,
+        backgroundSize: "contain",
+        backgroundRepeat: "no-repeat",
       }}
     />
   );


### PR DESCRIPTION
## Summary
Refactored the RecordingHandle component to use a `<div>` element with a CSS background image instead of an `<img>` element.

## Key Changes
- Changed the root element from `<img>` to `<div>`
- Moved the image source from the `src` attribute to a CSS `backgroundImage` property
- Added `backgroundSize: "contain"` to maintain proper image scaling
- Added `backgroundRepeat: "no-repeat"` to prevent image tiling
- Retained all existing functionality including drag behavior and positioning

## Implementation Details
The image URL generation logic remains unchanged, but is now applied as a CSS background image instead of being directly rendered as an image element. This approach provides better styling flexibility and allows the handle to be styled as a container element while maintaining the same visual appearance.

https://claude.ai/code/session_01X3uYt3uxh6MUBdEDmGJ6Qn