### PR TITLE
Allow IGNORE_SQUARE tool to work in "none" interaction mode

### DIFF
--- a/frontend/src/editor/components/stage/stage.tsx
+++ b/frontend/src/editor/components/stage/stage.tsx
@@ -813,7 +813,10 @@ export const Stage = ({
   };
 
   const onMouseDown = (event: React.MouseEvent) => {
-    if (playback.running || interactionMode === "none") {
+    if (playback.running) {
+      return;
+    }
+    if (interactionMode === "none" && selectedToolId !== TOOLS.IGNORE_SQUARE) {
       return;
     }
     const onMouseUpAnywhere = (e: MouseEvent) => {
@@ -957,7 +960,8 @@ export const Stage = ({
         TOOLS.STAMP === selectedToolId ||
         TOOLS.RECORD === selectedToolId ||
         TOOLS.PAINT === selectedToolId ||
-        TOOLS.CREATE_CHARACTER === selectedToolId
+        TOOLS.CREATE_CHARACTER === selectedToolId ||
+        TOOLS.IGNORE_SQUARE === selectedToolId
       ) {
         dispatch(selectToolId(TOOLS.POINTER));
       }


### PR DESCRIPTION
## Summary
This PR enables the IGNORE_SQUARE tool to function properly when the interaction mode is set to "none", while maintaining the existing behavior for other tools.

## Key Changes
- **Modified mouse down handler**: Split the playback check from the interaction mode check to allow IGNORE_SQUARE tool to bypass the "none" mode restriction
- **Updated tool deselection logic**: Added IGNORE_SQUARE to the list of tools that should be deselected when exiting certain states

## Implementation Details
The changes separate two distinct concerns in the `onMouseDown` handler:
1. Always prevent interactions when playback is running
2. Only prevent interactions in "none" mode for tools other than IGNORE_SQUARE, allowing this specific tool to remain functional

This allows the IGNORE_SQUARE tool to operate independently of the interaction mode setting, while preserving the existing behavior for all other tools (STAMP, RECORD, PAINT, CREATE_CHARACTER, and POINTER).

https://claude.ai/code/session_01USWFPs1tU4dzWPDYNLau4X