### PR TITLE
Exit immersive mode when fullscreen is exited externally

### DIFF
--- a/frontend/src/components/play-page.tsx
+++ b/frontend/src/components/play-page.tsx
@@ -37,14 +37,24 @@ const PlayPage: React.FC = () => {
   usePageTitle(world?.name);
   useHideRecaptchaBadge();
 
-  // Listen for fullscreen changes
+  // Listen for fullscreen changes — when the user exits fullscreen via the
+  // browser (Escape key, Safari controls, etc.), also leave immersive mode so
+  // the landing overlay with navigation links reappears.
   useEffect(() => {
     const onFullscreenChange = () => {
-      setIsFullscreen(!!document.fullscreenElement);
+      const nowFullscreen = !!document.fullscreenElement;
+      setIsFullscreen(nowFullscreen);
+      if (!nowFullscreen && immersive) {
+        // Fullscreen was exited externally — return to landing view
+        if (editorStoreRef.current) {
+          editorStoreRef.current.dispatch(updatePlaybackState({ speed: 500, running: false }));
+        }
+        setImmersive(false);
+      }
     };
     document.addEventListener("fullscreenchange", onFullscreenChange);
     return () => document.removeEventListener("fullscreenchange", onFullscreenChange);
-  }, []);
+  }, [immersive]);
 
   const startPlayback = useCallback(() => {
     if (editorStoreRef.current) {


### PR DESCRIPTION
## Summary
When users exit fullscreen mode via browser controls (Escape key, Safari fullscreen button, etc.) rather than through the app's UI, the immersive mode now automatically exits as well, restoring the landing overlay with navigation links.

## Changes
- Enhanced the fullscreen change listener to detect when fullscreen is exited externally
- When fullscreen is exited while in immersive mode, the app now:
  - Stops playback (sets speed to 500 and running to false)
  - Exits immersive mode to show the landing overlay
- Updated the effect dependency array to include `immersive` to ensure proper state synchronization
- Improved code clarity by extracting the fullscreen state into a variable before conditional checks

## Implementation Details
The fix leverages the existing `fullscreenchange` event listener and adds logic to detect the transition from fullscreen to non-fullscreen state. When this occurs and the user is in immersive mode, it dispatches a playback state update and exits immersive mode, providing a consistent UX regardless of how the user exits fullscreen.

https://claude.ai/code/session_01MgSozcxWpsNfAiPXFAAueg