### PR TITLE
Add missing type imports for World and Stage

### DIFF
--- a/frontend/src/editor/actions/stage-actions.ts
+++ b/frontend/src/editor/actions/stage-actions.ts
@@ -1,5 +1,5 @@
 import { DeepPartial, Dispatch } from "redux";
-import { Actor, ActorSelection, Character } from "../../types";
+import { Actor, ActorSelection, Character, Stage } from "../../types";
 import * as types from "../constants/action-types";
 
 import { Actions } from ".";

--- a/frontend/src/editor/reducers/world-reducer.ts
+++ b/frontend/src/editor/reducers/world-reducer.ts
@@ -3,7 +3,7 @@ import u from "updeep";
 
 import stageCollectionReducer from "./stage-collection-reducer";
 
-import { EditorState, WorldMinimal } from "../../types";
+import { EditorState, World, WorldMinimal } from "../../types";
 import { Actions } from "../actions";
 import * as Types from "../constants/action-types";
 import WorldOperator from "../utils/world-operator";
@@ -54,9 +54,9 @@ export default function worldReducer(
     }
     case Types.REWIND_ALL_GAME_STATE: {
       const { characters } = entireState;
-      let current = state;
+      let current = state as World;
       while (current.history && current.history.length > 0) {
-        current = WorldOperator(current, characters).untick();
+        current = WorldOperator(current, characters).untick() as World;
       }
       return current;
     }


### PR DESCRIPTION
## Summary
This PR adds missing type imports to improve type safety in the editor reducers and actions modules.

## Key Changes
- **world-reducer.ts**: 
  - Added `World` type import from types module
  - Added explicit type assertions (`as World`) to the `REWIND_ALL_GAME_STATE` reducer case to ensure proper type safety when reassigning `current` variable during the history rewind loop
  
- **stage-actions.ts**: 
  - Added `Stage` type import from types module for use in stage-related actions

## Implementation Details
The type assertions in the world reducer ensure that the `current` variable maintains the `World` type throughout the while loop that processes game state history, preventing potential type inference issues when calling `WorldOperator().untick()`.

https://claude.ai/code/session_01VqEbMxPFNjAEn9eUkNvDYX