### PR TITLE
Redesign play controls: symmetric layout with stoplight colors

### DIFF
--- a/frontend/src/editor/components/stage/stage-controls.tsx
+++ b/frontend/src/editor/components/stage/stage-controls.tsx
@@ -77,7 +77,7 @@ const StageControls: React.FC<StageControlsProps> = ({
 
       <div style={{ flex: 1 }} />
 
-      <div className="center transport-controls" data-tutorial-id="controls">
+      <div className={classNames("center transport-controls", { "is-playing": running })} data-tutorial-id="controls">
         {/* Reset - green, farthest left: most change backward */}
         {!readonly && (
           <button

--- a/frontend/src/editor/components/stage/stage-controls.tsx
+++ b/frontend/src/editor/components/stage/stage-controls.tsx
@@ -80,7 +80,7 @@ const StageControls: React.FC<StageControlsProps> = ({
       <div className={classNames("center transport-controls", { "is-playing": running })} data-tutorial-id="controls">
         {/* Reset - green, farthest left: most change backward */}
         {!readonly && (
-          <button
+          <Button
             className="transport-btn transport-green"
             disabled={world.history && world.history.length === 0}
             onClick={() => dispatch(rewindAllGameState(world.id))}
@@ -89,11 +89,11 @@ const StageControls: React.FC<StageControlsProps> = ({
               <rect x="0" y="1" width="2.5" height="12" />
               <polygon points="12,1 12,13 3,7" />
             </svg>
-          </button>
+          </Button>
         )}
         {/* Rewind - green, continuous backward play */}
         {!readonly && (
-          <button
+          <Button
             className={classNames("transport-btn transport-green", { selected: rewinding })}
             disabled={!rewinding && world.history && world.history.length === 0}
             onClick={() =>
@@ -107,11 +107,11 @@ const StageControls: React.FC<StageControlsProps> = ({
             <svg width="16" height="18" viewBox="0 0 12 14" fill="currentColor">
               <polygon points="12,1 12,13 0,7" />
             </svg>
-          </button>
+          </Button>
         )}
         {/* Step Backward - yellow, one tick back */}
         {!readonly && (
-          <button
+          <Button
             className="transport-btn transport-yellow"
             disabled={world.history && world.history.length === 0}
             onClick={() => dispatch(stepBackGameState(world.id))}
@@ -120,20 +120,20 @@ const StageControls: React.FC<StageControlsProps> = ({
               <polygon points="12,1 12,13 2,7" />
               <rect x="0" y="1" width="2.5" height="12" />
             </svg>
-          </button>
+          </Button>
         )}
         {/* Stop - red, center */}
-        <button
+        <Button
           className={classNames("transport-btn transport-red", { selected: !running })}
           onClick={() => dispatch(updatePlaybackState({ speed, running: false }))}
         >
           <svg width="14" height="14" viewBox="0 0 12 12" fill="currentColor">
             <rect x="0" y="0" width="12" height="12" rx="1" />
           </svg>
-        </button>
+        </Button>
         {/* Step Forward - yellow, one tick forward */}
         {!readonly && (
-          <button
+          <Button
             className="transport-btn transport-yellow"
             onClick={() => dispatch(advanceGameState(world.id))}
           >
@@ -141,10 +141,10 @@ const StageControls: React.FC<StageControlsProps> = ({
               <polygon points="2,1 2,13 12,7" />
               <rect x="11.5" y="1" width="2.5" height="12" />
             </svg>
-          </button>
+          </Button>
         )}
         {/* Play - green, continuous forward play */}
-        <button
+        <Button
           data-tutorial-id="play"
           className={classNames("transport-btn transport-green", {
             selected: running && runningDirection === "forward",
@@ -156,7 +156,7 @@ const StageControls: React.FC<StageControlsProps> = ({
           <svg width="16" height="18" viewBox="0 0 12 14" fill="currentColor">
             <polygon points="0,1 0,13 12,7" />
           </svg>
-        </button>
+        </Button>
         {/* Clock */}
         <TickClock running={running} speed={speed} tickKey={world.evaluatedTickFrames?.[0]?.id} />
       </div>

--- a/frontend/src/editor/components/stage/stage-controls.tsx
+++ b/frontend/src/editor/components/stage/stage-controls.tsx
@@ -85,7 +85,7 @@ const StageControls: React.FC<StageControlsProps> = ({
             disabled={world.history && world.history.length === 0}
             onClick={() => dispatch(rewindAllGameState(world.id))}
           >
-            <svg width="14" height="14" viewBox="0 0 14 14" fill="currentColor">
+            <svg width="18" height="18" viewBox="0 0 14 14" fill="currentColor">
               <rect x="0" y="1" width="2.5" height="12" />
               <polygon points="12,1 12,13 3,7" />
             </svg>
@@ -104,7 +104,7 @@ const StageControls: React.FC<StageControlsProps> = ({
               )
             }
           >
-            <svg width="12" height="14" viewBox="0 0 12 14" fill="currentColor">
+            <svg width="16" height="18" viewBox="0 0 12 14" fill="currentColor">
               <polygon points="12,1 12,13 0,7" />
             </svg>
           </button>
@@ -116,7 +116,7 @@ const StageControls: React.FC<StageControlsProps> = ({
             disabled={world.history && world.history.length === 0}
             onClick={() => dispatch(stepBackGameState(world.id))}
           >
-            <svg width="14" height="14" viewBox="0 0 14 14" fill="currentColor">
+            <svg width="18" height="18" viewBox="0 0 14 14" fill="currentColor">
               <polygon points="12,1 12,13 2,7" />
               <rect x="0" y="1" width="2.5" height="12" />
             </svg>
@@ -127,7 +127,7 @@ const StageControls: React.FC<StageControlsProps> = ({
           className={classNames("transport-btn transport-red", { selected: !running })}
           onClick={() => dispatch(updatePlaybackState({ speed, running: false }))}
         >
-          <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor">
+          <svg width="14" height="14" viewBox="0 0 12 12" fill="currentColor">
             <rect x="0" y="0" width="12" height="12" rx="1" />
           </svg>
         </button>
@@ -137,7 +137,7 @@ const StageControls: React.FC<StageControlsProps> = ({
             className="transport-btn transport-yellow"
             onClick={() => dispatch(advanceGameState(world.id))}
           >
-            <svg width="14" height="14" viewBox="0 0 14 14" fill="currentColor">
+            <svg width="18" height="18" viewBox="0 0 14 14" fill="currentColor">
               <polygon points="2,1 2,13 12,7" />
               <rect x="11.5" y="1" width="2.5" height="12" />
             </svg>
@@ -153,7 +153,7 @@ const StageControls: React.FC<StageControlsProps> = ({
             dispatch(updatePlaybackState({ speed, running: true, runningDirection: "forward" }))
           }
         >
-          <svg width="12" height="14" viewBox="0 0 12 14" fill="currentColor">
+          <svg width="16" height="18" viewBox="0 0 12 14" fill="currentColor">
             <polygon points="0,1 0,13 12,7" />
           </svg>
         </button>

--- a/frontend/src/editor/components/stage/stage-controls.tsx
+++ b/frontend/src/editor/components/stage/stage-controls.tsx
@@ -77,38 +77,24 @@ const StageControls: React.FC<StageControlsProps> = ({
 
       <div style={{ flex: 1 }} />
 
-      <div className="center" data-tutorial-id="controls">
+      <div className="center transport-controls" data-tutorial-id="controls">
+        {/* Reset - green, farthest left: most change backward */}
         {!readonly && (
-          <Button
-            size="sm"
+          <button
+            className="transport-btn transport-green"
             disabled={world.history && world.history.length === 0}
             onClick={() => dispatch(rewindAllGameState(world.id))}
           >
-            <svg
-              width="12"
-              height="12"
-              viewBox="0 0 12 12"
-              fill="currentColor"
-              style={{ verticalAlign: "middle" }}
-            >
-              <rect x="0" y="1" width="2" height="10" />
-              <polygon points="7,1 7,11 2,6" />
-              <polygon points="12,1 12,11 7,6" />
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="currentColor">
+              <rect x="0" y="1" width="2.5" height="12" />
+              <polygon points="12,1 12,13 3,7" />
             </svg>
-          </Button>
-        )}{" "}
+          </button>
+        )}
+        {/* Rewind - green, continuous backward play */}
         {!readonly && (
-          <Button
-            size="sm"
-            disabled={world.history && world.history.length === 0}
-            onClick={() => dispatch(stepBackGameState(world.id))}
-          >
-            <i className="fa fa-step-backward" />
-          </Button>
-        )}{" "}
-        {!readonly && (
-          <Button
-            className={classNames({ selected: rewinding })}
+          <button
+            className={classNames("transport-btn transport-green", { selected: rewinding })}
             disabled={!rewinding && world.history && world.history.length === 0}
             onClick={() =>
               dispatch(
@@ -118,29 +104,60 @@ const StageControls: React.FC<StageControlsProps> = ({
               )
             }
           >
-            <i className="fa fa-backward" />
-          </Button>
-        )}{" "}
-        <Button
-          className={classNames({ selected: !running })}
+            <svg width="12" height="14" viewBox="0 0 12 14" fill="currentColor">
+              <polygon points="12,1 12,13 0,7" />
+            </svg>
+          </button>
+        )}
+        {/* Step Backward - yellow, one tick back */}
+        {!readonly && (
+          <button
+            className="transport-btn transport-yellow"
+            disabled={world.history && world.history.length === 0}
+            onClick={() => dispatch(stepBackGameState(world.id))}
+          >
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="currentColor">
+              <polygon points="12,1 12,13 2,7" />
+              <rect x="0" y="1" width="2.5" height="12" />
+            </svg>
+          </button>
+        )}
+        {/* Stop - red, center */}
+        <button
+          className={classNames("transport-btn transport-red", { selected: !running })}
           onClick={() => dispatch(updatePlaybackState({ speed, running: false }))}
         >
-          <i className="fa fa-stop" />
-        </Button>{" "}
-        <Button
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor">
+            <rect x="0" y="0" width="12" height="12" rx="1" />
+          </svg>
+        </button>
+        {/* Step Forward - yellow, one tick forward */}
+        {!readonly && (
+          <button
+            className="transport-btn transport-yellow"
+            onClick={() => dispatch(advanceGameState(world.id))}
+          >
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="currentColor">
+              <polygon points="2,1 2,13 12,7" />
+              <rect x="11.5" y="1" width="2.5" height="12" />
+            </svg>
+          </button>
+        )}
+        {/* Play - green, continuous forward play */}
+        <button
           data-tutorial-id="play"
-          className={classNames({ selected: running && runningDirection === "forward" })}
+          className={classNames("transport-btn transport-green", {
+            selected: running && runningDirection === "forward",
+          })}
           onClick={() =>
             dispatch(updatePlaybackState({ speed, running: true, runningDirection: "forward" }))
           }
         >
-          <i className="fa fa-play" />
-        </Button>{" "}
-        {!readonly && (
-          <Button size="sm" onClick={() => dispatch(advanceGameState(world.id))}>
-            <i className="fa fa-step-forward" />
-          </Button>
-        )}{" "}
+          <svg width="12" height="14" viewBox="0 0 12 14" fill="currentColor">
+            <polygon points="0,1 0,13 12,7" />
+          </svg>
+        </button>
+        {/* Clock */}
         <TickClock running={running} speed={speed} tickKey={world.evaluatedTickFrames?.[0]?.id} />
       </div>
 

--- a/frontend/src/editor/styles/editor.scss
+++ b/frontend/src/editor/styles/editor.scss
@@ -525,7 +525,7 @@ html {
     }
 
     .transport-btn.btn {
-      padding: 2px 6px;
+      padding: 4px 8px;
       transition: opacity 0.15s ease;
 
       svg {

--- a/frontend/src/editor/styles/editor.scss
+++ b/frontend/src/editor/styles/editor.scss
@@ -508,6 +508,60 @@ html {
     .center {
       text-align: center;
     }
+
+    .transport-controls {
+      display: inline-flex;
+      align-items: center;
+      gap: 3px;
+    }
+
+    .transport-btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 32px;
+      height: 28px;
+      border: none;
+      border-radius: 3px;
+      cursor: pointer;
+      padding: 0;
+      transition: filter 0.1s ease, transform 0.1s ease;
+      background: transparent;
+
+      &:disabled {
+        opacity: 0.3;
+        cursor: default;
+      }
+
+      &:not(:disabled):hover {
+        filter: brightness(1.2);
+      }
+
+      &:not(:disabled):active,
+      &.selected {
+        transform: scale(0.92);
+        filter: brightness(0.85);
+      }
+
+      &.selected {
+        filter: brightness(0.85) saturate(1.3);
+      }
+
+      svg {
+        display: block;
+      }
+    }
+
+    .transport-green {
+      color: #2eac1c;
+    }
+    .transport-yellow {
+      color: #c8a80e;
+    }
+    .transport-red {
+      color: #d42a2a;
+    }
+
     .right {
       flex-shrink: 0;
     }

--- a/frontend/src/editor/styles/editor.scss
+++ b/frontend/src/editor/styles/editor.scss
@@ -516,38 +516,34 @@ html {
 
       // When playing/rewinding, dim non-active buttons
       &.is-playing .transport-btn:not(.selected) {
-        opacity: 0.4;
+        opacity: 0.45;
 
         &:not(:disabled):hover {
-          opacity: 0.7;
+          opacity: 0.8;
         }
       }
     }
 
-    .transport-btn {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      width: 36px;
-      height: 32px;
-      border: none;
-      border-radius: 3px;
-      cursor: pointer;
-      padding: 0;
+    .transport-btn.btn {
+      padding: 2px 6px;
       transition: opacity 0.15s ease;
-      background: transparent;
-
-      &:disabled {
-        opacity: 0.25;
-        cursor: default;
-      }
-
-      &:not(:disabled):hover {
-        opacity: 0.7;
-      }
 
       svg {
         display: block;
+      }
+
+      // Color-specific selected states (override the global tint-color selected style)
+      &.transport-green.selected {
+        background-image: linear-gradient(#2eac1c, #1e7a13);
+        color: white;
+      }
+      &.transport-yellow.selected {
+        background-image: linear-gradient(#c8a80e, #9a820a);
+        color: white;
+      }
+      &.transport-red.selected {
+        background-image: linear-gradient(#d42a2a, #a11e1e);
+        color: white;
       }
     }
 

--- a/frontend/src/editor/styles/editor.scss
+++ b/frontend/src/editor/styles/editor.scss
@@ -526,6 +526,7 @@ html {
 
     .transport-btn.btn {
       padding: 4px 8px;
+      height: 31px;
       transition: opacity 0.15s ease;
 
       svg {

--- a/frontend/src/editor/styles/editor.scss
+++ b/frontend/src/editor/styles/editor.scss
@@ -513,6 +513,15 @@ html {
       display: inline-flex;
       align-items: center;
       gap: 3px;
+
+      // When playing/rewinding, dim non-active buttons
+      &.is-playing .transport-btn:not(.selected) {
+        opacity: 0.4;
+
+        &:not(:disabled):hover {
+          opacity: 0.7;
+        }
+      }
     }
 
     .transport-btn {
@@ -525,25 +534,16 @@ html {
       border-radius: 3px;
       cursor: pointer;
       padding: 0;
-      transition: filter 0.15s ease, opacity 0.15s ease;
+      transition: opacity 0.15s ease;
       background: transparent;
-      opacity: 0.45;
 
       &:disabled {
-        opacity: 0.2;
+        opacity: 0.25;
         cursor: default;
       }
 
       &:not(:disabled):hover {
-        opacity: 0.75;
-      }
-
-      &:not(:disabled):active {
-        opacity: 1;
-      }
-
-      &.selected {
-        opacity: 1;
+        opacity: 0.7;
       }
 
       svg {

--- a/frontend/src/editor/styles/editor.scss
+++ b/frontend/src/editor/styles/editor.scss
@@ -519,32 +519,31 @@ html {
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      width: 32px;
-      height: 28px;
+      width: 36px;
+      height: 32px;
       border: none;
       border-radius: 3px;
       cursor: pointer;
       padding: 0;
-      transition: filter 0.1s ease, transform 0.1s ease;
+      transition: filter 0.15s ease, opacity 0.15s ease;
       background: transparent;
+      opacity: 0.45;
 
       &:disabled {
-        opacity: 0.3;
+        opacity: 0.2;
         cursor: default;
       }
 
       &:not(:disabled):hover {
-        filter: brightness(1.2);
+        opacity: 0.75;
       }
 
-      &:not(:disabled):active,
-      &.selected {
-        transform: scale(0.92);
-        filter: brightness(0.85);
+      &:not(:disabled):active {
+        opacity: 1;
       }
 
       &.selected {
-        filter: brightness(0.85) saturate(1.3);
+        opacity: 1;
       }
 
       svg {


### PR DESCRIPTION
Rearrange transport buttons to be symmetric around Stop: Reset | Rewind | StepBack | Stop | StepFwd | Play | Clock. Replace FontAwesome icons with inline SVGs using stoplight colors (green=go, yellow=step, red=stop). Simplify to borderless buttons with press-to-depress interaction, matching Creator's visual style.

https://claude.ai/code/session_01SwYcHy6kVnVxybcyMhQteR