### PR TITLE
Add shortcuts for creating containers with click and key rules

### DIFF
--- a/frontend/src/editor/actions/ui-actions.ts
+++ b/frontend/src/editor/actions/ui-actions.ts
@@ -94,6 +94,22 @@ export function pickConditionValueFromKeyboard(
       open,
       initialKey,
       replaceConditionKey,
+      purpose: "condition",
+      characterId: null,
+    });
+  };
+}
+
+export function pickKeyForEventContainer(open: boolean, characterId: string | null) {
+  return (dispatch: Dispatch<Actions>) => {
+    dispatch(stopPlayback());
+    dispatch({
+      type: types.UPDATE_KEYPICKER_STATE,
+      open,
+      initialKey: null,
+      replaceConditionKey: null,
+      purpose: "event-container",
+      characterId,
     });
   };
 }
@@ -155,6 +171,8 @@ export type ActionUpdateKeypickerState = {
   open: boolean;
   initialKey: string | null;
   replaceConditionKey: string | null;
+  purpose: "condition" | "event-container";
+  characterId: string | null;
 };
 
 export type ActionUpdateTutorialState = {

--- a/frontend/src/editor/components/inspector/add-rule-button.tsx
+++ b/frontend/src/editor/components/inspector/add-rule-button.tsx
@@ -75,10 +75,10 @@ const RuleAddButton = ({
           <span className="badge rule-flow" /> Add Container
         </DropdownItem>
         <DropdownItem onClick={_onCreateFlowContainerWithClick}>
-          <span className="badge rule-flow" /> Add Click Container
+          <span className="badge rule-flow" /> Add Container with Click Test
         </DropdownItem>
         <DropdownItem onClick={_onCreateFlowContainerWithKeyPress}>
-          <span className="badge rule-flow" /> Add Key Press Container
+          <span className="badge rule-flow" /> Add Container with Key Test
         </DropdownItem>
       </DropdownMenu>
     </ButtonDropdown>

--- a/frontend/src/editor/components/inspector/add-rule-button.tsx
+++ b/frontend/src/editor/components/inspector/add-rule-button.tsx
@@ -43,7 +43,7 @@ const RuleAddButton = ({
     dispatch(createCharacterFlowContainer(character.id, { id }));
   };
 
-  const _onCreateClickContainer = () => {
+  const _onCreateFlowContainerWithClick = () => {
     dispatch(
       createCharacterEventContainer(character.id, {
         id: makeId("rule"),
@@ -53,7 +53,7 @@ const RuleAddButton = ({
     );
   };
 
-  const _onCreateKeyContainer = () => {
+  const _onCreateFlowContainerWithKeyPress = () => {
     dispatch(pickKeyForEventContainer(true, character.id));
   };
 
@@ -72,13 +72,13 @@ const RuleAddButton = ({
         </DropdownItem>
         <DropdownItem divider />
         <DropdownItem onClick={_onCreateFlowContainer}>
-          <span className="badge rule-flow" /> Add Rule Container
+          <span className="badge rule-flow" /> Add Container
         </DropdownItem>
-        <DropdownItem onClick={_onCreateClickContainer}>
-          <span className="badge rule-flow" /> Add Click Rule Container
+        <DropdownItem onClick={_onCreateFlowContainerWithClick}>
+          <span className="badge rule-flow" /> Add Click Container
         </DropdownItem>
-        <DropdownItem onClick={_onCreateKeyContainer}>
-          <span className="badge rule-flow" /> Add Key Rule Container
+        <DropdownItem onClick={_onCreateFlowContainerWithKeyPress}>
+          <span className="badge rule-flow" /> Add Key Press Container
         </DropdownItem>
       </DropdownMenu>
     </ButtonDropdown>

--- a/frontend/src/editor/components/inspector/add-rule-button.tsx
+++ b/frontend/src/editor/components/inspector/add-rule-button.tsx
@@ -4,12 +4,15 @@ import { useState } from "react";
 
 import { useDispatch } from "react-redux";
 import { Actor, Character } from "../../../types";
-import { createCharacterFlowContainer } from "../../actions/characters-actions";
+import {
+  createCharacterEventContainer,
+  createCharacterFlowContainer,
+} from "../../actions/characters-actions";
 import {
   setupRecordingForActor,
   setupRecordingForCharacter,
 } from "../../actions/recording-actions";
-import { selectToolId } from "../../actions/ui-actions";
+import { pickKeyForEventContainer, selectToolId } from "../../actions/ui-actions";
 import { TOOLS } from "../../constants/constants";
 import { makeId } from "../../utils/utils";
 
@@ -40,6 +43,20 @@ const RuleAddButton = ({
     dispatch(createCharacterFlowContainer(character.id, { id }));
   };
 
+  const _onCreateClickContainer = () => {
+    dispatch(
+      createCharacterEventContainer(character.id, {
+        id: makeId("rule"),
+        eventType: "click",
+        eventCode: undefined,
+      }),
+    );
+  };
+
+  const _onCreateKeyContainer = () => {
+    dispatch(pickKeyForEventContainer(true, character.id));
+  };
+
   return (
     <ButtonDropdown
       isOpen={open}
@@ -56,6 +73,12 @@ const RuleAddButton = ({
         <DropdownItem divider />
         <DropdownItem onClick={_onCreateFlowContainer}>
           <span className="badge rule-flow" /> Add Rule Container
+        </DropdownItem>
+        <DropdownItem onClick={_onCreateClickContainer}>
+          <span className="badge rule-flow" /> Add Click Rule Container
+        </DropdownItem>
+        <DropdownItem onClick={_onCreateKeyContainer}>
+          <span className="badge rule-flow" /> Add Key Rule Container
         </DropdownItem>
       </DropdownMenu>
     </ButtonDropdown>

--- a/frontend/src/editor/components/modal-keypicker/container.tsx
+++ b/frontend/src/editor/components/modal-keypicker/container.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
 
 import { useEditorSelector } from "../../../hooks/redux";
+import { createCharacterEventContainer } from "../../actions/characters-actions";
 import { upsertRecordingCondition } from "../../actions/recording-actions";
 import { pickConditionValueFromKeyboard } from "../../actions/ui-actions";
 import { makeId } from "../../utils/utils";
@@ -10,7 +11,7 @@ import Keyboard, { keyToCodakoKey } from "./keyboard";
 
 export const KeypickerContainer = () => {
   const dispatch = useDispatch();
-  const { open, initialKey, replaceConditionKey } = useEditorSelector(
+  const { open, initialKey, replaceConditionKey, purpose, characterId } = useEditorSelector(
     (state) => state.ui.keypicker,
   );
 
@@ -33,6 +34,18 @@ export const KeypickerContainer = () => {
     }
 
     dispatch(pickConditionValueFromKeyboard(false, null, null));
+
+    if (purpose === "event-container" && characterId) {
+      dispatch(
+        createCharacterEventContainer(characterId, {
+          id: makeId("rule"),
+          eventType: "key",
+          eventCode: key,
+        }),
+      );
+      return;
+    }
+
     dispatch(
       upsertRecordingCondition({
         key: replaceConditionKey || makeId("condition"),

--- a/frontend/src/editor/reducers/initial-state.ts
+++ b/frontend/src/editor/reducers/initial-state.ts
@@ -71,6 +71,8 @@ const InitialState: EditorState = {
       open: false,
       initialKey: null,
       replaceConditionKey: null,
+      purpose: "condition" as const,
+      characterId: null,
     },
     paint: {
       characterId: null,

--- a/frontend/src/editor/utils/event-helpers.ts
+++ b/frontend/src/editor/utils/event-helpers.ts
@@ -1,6 +1,17 @@
-export function nameForKey(code: number) {
+export function nameForKey(code: number | string | undefined) {
   if (!code) {
     return "";
+  }
+  if (typeof code === "string") {
+    return (
+      {
+        Space: "Space Bar",
+        ArrowLeft: "Left Arrow",
+        ArrowRight: "Right Arrow",
+        ArrowUp: "Up Arrow",
+        ArrowDown: "Down Arrow",
+      }[code] || code
+    );
   }
   return (
     {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -99,7 +99,7 @@ export type RuleTreeEventItem = {
   type: "group-event";
   rules: RuleTreeItem[];
   event: "idle" | "key" | "click";
-  code?: number; // used for key event
+  code?: number | string; // used for key event (legacy numeric keyCode or codako key name)
   id: string;
   enabled?: boolean;
 };
@@ -384,6 +384,8 @@ export type UIState = {
     open: boolean | null;
     replaceConditionKey: string | null;
     initialKey: string | null;
+    purpose?: "condition" | "event-container";
+    characterId?: string | null;
   };
   paint: {
     characterId: string | null;


### PR DESCRIPTION
## Summary
This PR extends the rule system to support event-based containers for click and key events, in addition to the existing flow containers. Users can now create dedicated rule containers that trigger on specific keyboard keys or click events.

## Key Changes
- **New event container actions**: Added `createCharacterEventContainer` action to create rule containers with event triggers
- **UI enhancements**: Extended the "Add Rule" dropdown menu with two new options:
  - "Add Click Rule Container" - creates a rule container triggered by click events
  - "Add Key Rule Container" - opens a key picker to create a rule container for a specific key
- **Key picker refactoring**: Enhanced the keypicker modal to support dual purposes:
  - "condition" mode (existing behavior for condition values)
  - "event-container" mode (new behavior for creating key-triggered rule containers)
- **Type system updates**: 
  - Extended `ActionUpdateKeypickerState` to include `purpose` and `characterId` fields
  - Updated `RuleTreeEventItem.code` type to accept both numeric keyCodes and string key names for better flexibility
- **Key name mapping**: Enhanced `nameForKey()` utility to handle string-based key codes (e.g., "Space", "ArrowLeft") in addition to numeric codes

## Implementation Details
- The keypicker now tracks its purpose and associated character ID to determine whether to create a condition or event container
- Event containers store the event type ("click" or "key") and optional event code for key events
- The UI state initialization includes default values for the new keypicker fields to maintain backward compatibility

https://claude.ai/code/session_01LdxWg4ZuHc7xEUB6nvw5i6