### PR TITLE
Refactor door variable retrieval to use helper function

### DIFF
--- a/frontend/src/editor/components/stage/stage.tsx
+++ b/frontend/src/editor/components/stage/stage.tsx
@@ -44,6 +44,7 @@ import {
   actorsAtPoint,
   applyAnchorAdjustment,
   buildActorSelection,
+  getVariableValue,
   pointIsOutside,
   sortActorsByZOrder,
 } from "../../utils/stage-helpers";
@@ -1112,17 +1113,10 @@ export const Stage = ({
       const character = characters[actor.characterId];
       if (character?.kind !== "door") continue;
 
-      const defaults = character.variables;
-      const destXRaw =
-        actor.variableValues[DOOR_VARIABLE_IDS.destinationX] ??
-        defaults[DOOR_VARIABLE_IDS.destinationX]?.defaultValue;
-      const destYRaw =
-        actor.variableValues[DOOR_VARIABLE_IDS.destinationY] ??
-        defaults[DOOR_VARIABLE_IDS.destinationY]?.defaultValue;
+      const destXRaw = getVariableValue(actor, character, DOOR_VARIABLE_IDS.destinationX, "=");
+      const destYRaw = getVariableValue(actor, character, DOOR_VARIABLE_IDS.destinationY, "=");
       const destStageId =
-        actor.variableValues[DOOR_VARIABLE_IDS.destinationStage] ??
-        defaults[DOOR_VARIABLE_IDS.destinationStage]?.defaultValue ??
-        "";
+        getVariableValue(actor, character, DOOR_VARIABLE_IDS.destinationStage, "=") ?? "";
 
       const destX = Number(destXRaw);
       const destY = Number(destYRaw);

--- a/frontend/src/editor/utils/door-constants.ts
+++ b/frontend/src/editor/utils/door-constants.ts
@@ -1,4 +1,5 @@
 import { Character, Characters, Position, WorldMinimal } from "../../types";
+import { getVariableValue } from "./stage-helpers";
 
 export const DOOR_VARIABLE_IDS = {
   destinationX: "door-dest-x",
@@ -55,16 +56,10 @@ export function collectDoorsByDestinationStage(
       const character = characters[actor.characterId];
       if (character?.kind !== "door") continue;
 
-      const destXRaw =
-        actor.variableValues[DOOR_VARIABLE_IDS.destinationX] ??
-        character.variables[DOOR_VARIABLE_IDS.destinationX]?.defaultValue;
-      const destYRaw =
-        actor.variableValues[DOOR_VARIABLE_IDS.destinationY] ??
-        character.variables[DOOR_VARIABLE_IDS.destinationY]?.defaultValue;
+      const destXRaw = getVariableValue(actor, character, DOOR_VARIABLE_IDS.destinationX, "=");
+      const destYRaw = getVariableValue(actor, character, DOOR_VARIABLE_IDS.destinationY, "=");
       const destStageId =
-        actor.variableValues[DOOR_VARIABLE_IDS.destinationStage] ??
-        character.variables[DOOR_VARIABLE_IDS.destinationStage]?.defaultValue ??
-        "";
+        getVariableValue(actor, character, DOOR_VARIABLE_IDS.destinationStage, "=") ?? "";
 
       const destX = Number(destXRaw);
       const destY = Number(destYRaw);


### PR DESCRIPTION
## Summary
Refactored door variable retrieval logic to use a centralized `getVariableValue` helper function, eliminating code duplication and improving maintainability.

## Key Changes
- Imported `getVariableValue` helper function from `stage-helpers` into both `stage.tsx` and `door-constants.ts`
- Replaced repetitive variable value lookup patterns in two locations:
  - `stage.tsx`: Door destination coordinate and stage ID retrieval in the stage component
  - `door-constants.ts`: Same variable retrieval in the `collectDoorsByDestinationStage` function
- The helper function handles the fallback logic: checking actor-specific variable values first, then falling back to character default values

## Implementation Details
- The `getVariableValue` function abstracts the pattern of checking `actor.variableValues[id]` first, then falling back to `character.variables[id]?.defaultValue`
- All calls use `"="` as the operator parameter, indicating direct value assignment/retrieval
- This change reduces code duplication and makes future variable retrieval logic changes easier to maintain in a single location

https://claude.ai/code/session_0116DQpfeyAUxBJwxvQUm9jk