### PR TITLE
Always enable full interaction mode in stage container

### DIFF
--- a/frontend/src/editor/components/stage/container.tsx
+++ b/frontend/src/editor/components/stage/container.tsx
@@ -84,7 +84,7 @@ const StageContainer = ({ readonly, immersive }: { readonly?: boolean; immersive
           recordingExtent={recording.extent}
           recordingCentered
           evaluatedSquares={evaluatedSquares}
-          interactionMode={recording.actions === null ? "full" : "none"}
+          interactionMode="full"
         />
       );
       if (recording.actions !== null) {


### PR DESCRIPTION
## Summary
Simplified the interaction mode logic in the StageContainer component by always setting it to "full" mode, removing the conditional behavior that previously disabled interactions when recording actions were present.

## Changes
- Changed `interactionMode` from a conditional expression (`recording.actions === null ? "full" : "none"`) to always be `"full"`
- This allows users to interact with the stage regardless of whether recording actions exist

## Implementation Details
The interaction mode is now unconditionally set to "full", which means the stage will always be in full interaction mode. The check for `recording.actions !== null` still exists in the subsequent code block, suggesting that recording action handling is managed separately from the interaction mode setting.

https://claude.ai/code/session_01Y77D7FkBYj4PHdmUV8cPrN