### PR TITLE
Add backgroundFade property to initial stage configuration

### DIFF
--- a/frontend/src/editor/reducers/initial-state-stage.ts
+++ b/frontend/src/editor/reducers/initial-state-stage.ts
@@ -10,6 +10,7 @@ const InitialStage: Stage = {
   height: 13,
   wrapX: true,
   wrapY: true,
+  backgroundFade: false,
 };
 
 export default InitialStage;


### PR DESCRIPTION
## Summary
Added the `backgroundFade` property to the initial stage configuration with a default value of `false`.

## Changes
- Added `backgroundFade: false` to the `InitialStage` object in the stage reducer's initial state

## Details
This change initializes the `backgroundFade` property for all new stages, ensuring the property is defined from the start rather than being undefined. The default value of `false` maintains the current visual behavior while allowing this property to be toggled as needed.

https://claude.ai/code/session_01FmRvvE1NREa3uL32M3kTXu