### PR TITLE
Allow copying full image when no selection exists

### DIFF
--- a/frontend/src/editor/components/modal-paint/container.tsx
+++ b/frontend/src/editor/components/modal-paint/container.tsx
@@ -289,8 +289,8 @@ const PaintContainer: React.FC = () => {
               <DropdownItem disabled={!state.selectionImageData} onClick={() => model.cut()}>
                 Cut Selection
               </DropdownItem>
-              <DropdownItem disabled={!state.selectionImageData} onClick={() => model.copy()}>
-                Copy Selection
+              <DropdownItem onClick={() => model.copy()}>
+                {state.selectionImageData ? "Copy Selection" : "Copy Image"}
               </DropdownItem>
               <DropdownItem onClick={() => model.paste()}>Paste</DropdownItem>
               <DropdownItem divider />

--- a/frontend/src/editor/components/modal-paint/paint-model.ts
+++ b/frontend/src/editor/components/modal-paint/paint-model.ts
@@ -224,11 +224,14 @@ export class PaintModel {
   async copy(): Promise<void> {
     if (this.state.imageData === null) return;
 
+    const imageDataToCopy = this.state.selectionImageData ?? this.state.imageData;
+    const offsetToCopy = this.state.selectionImageData ? this.state.selectionOffset : { x: 0, y: 0 };
+
     const data: Record<string, Blob | string> = {
-      "text/plain": JSON.stringify(this.state.selectionOffset),
+      "text/plain": JSON.stringify(offsetToCopy),
     };
 
-    const blob = await getBlobFromImageData(this.state.selectionImageData);
+    const blob = await getBlobFromImageData(imageDataToCopy);
     if (blob) {
       data["image/png"] = blob;
     }


### PR DESCRIPTION
## Summary
Updated the copy functionality in the paint editor to allow copying the entire image when no selection is active, rather than disabling the copy option entirely.

## Key Changes
- Modified `PaintModel.copy()` to use the full image data when no selection exists, falling back to `selectionImageData` only when available
- Updated the offset logic to use `{ x: 0, y: 0 }` for full image copies instead of the selection offset
- Changed the "Copy Selection" menu item to be always enabled, with dynamic label that shows "Copy Image" when no selection is active
- Removed the `disabled={!state.selectionImageData}` condition from the copy button

## Implementation Details
The copy operation now intelligently determines what to copy:
- If a selection exists: copies the selected image data with the selection offset
- If no selection exists: copies the full image data with zero offset

This provides a more intuitive user experience by allowing users to copy the entire image without needing to first create a selection.

https://claude.ai/code/session_019rmLVAvwnQseQqG6hSY1id