### PR TITLE
Rename "Stage" to "Level" throughout the application

### DIFF
--- a/frontend/src/components/home-page.tsx
+++ b/frontend/src/components/home-page.tsx
@@ -39,7 +39,7 @@ const HomePage = () => {
                 <div style={{ display: "flex", gap: 12, alignItems: "center" }}>
                   <img src={new URL("../img/new-game-tutorial.png", import.meta.url).href} />
                   <div style={{ textAlign: "left", height: 72 }}>
-                    <strong>Tutorial Stage (Recommended)</strong>
+                    <strong>Tutorial Level (Recommended)</strong>
                     <p>
                       Learn how to use Codako's drag-and-drop interface to create characters,
                       appearances, and rules.
@@ -51,7 +51,7 @@ const HomePage = () => {
                 <div style={{ display: "flex", gap: 12, alignItems: "center" }}>
                   <img src={new URL("../img/new-game-empty.png", import.meta.url).href} />
                   <div style={{ textAlign: "left", height: 72 }}>
-                    <strong>Blank Stage</strong>
+                    <strong>Blank Level</strong>
                     <p>Start from scratch, add characters and design your own game world!</p>
                   </div>
                 </div>

--- a/frontend/src/editor/actions/characters-actions.ts
+++ b/frontend/src/editor/actions/characters-actions.ts
@@ -74,7 +74,7 @@ export function createDoorCharacter(newId: string): ActionUpsertCharacter {
         },
         [DOOR_VARIABLE_IDS.destinationStage]: {
           id: DOOR_VARIABLE_IDS.destinationStage,
-          name: "Destination Stage",
+          name: "Destination Level",
           defaultValue: "",
           type: "stage",
         },

--- a/frontend/src/editor/components/modal-stages/container.tsx
+++ b/frontend/src/editor/components/modal-stages/container.tsx
@@ -73,7 +73,7 @@ export const StagesContainer = () => {
       style={{ minWidth: 780, maxWidth: 780 }}
     >
       <div className="modal-header" style={{ display: "flex" }}>
-        <h4 style={{ flex: 1 }}>Stages</h4>
+        <h4 style={{ flex: 1 }}>Levels</h4>
       </div>
       <div style={{ display: "flex", flexDirection: "row", justifyContent: "stretch" }}>
         <div className="stage-sidebar">
@@ -93,7 +93,7 @@ export const StagesContainer = () => {
               <div className="add-stage-placeholder">
                 <i className="fa fa-plus" />
               </div>
-              <h3>Add Stage</h3>
+              <h3>Add Level</h3>
             </div>
           </div>
           <div className="bar">

--- a/frontend/src/editor/components/stage-switcher.tsx
+++ b/frontend/src/editor/components/stage-switcher.tsx
@@ -53,8 +53,8 @@ export const StageSwitcher = () => {
       </ButtonDropdown>
       <Button
         className="stage-switcher-settings"
-        title="Stage settings"
-        aria-label="Stage settings"
+        title="Level settings"
+        aria-label="Level settings"
         onClick={() => dispatch(actions.showModal(MODALS.STAGES))}
       >
         <GearIcon />

--- a/frontend/src/editor/components/stage/recording/panel-actions.tsx
+++ b/frontend/src/editor/components/stage/recording/panel-actions.tsx
@@ -182,7 +182,7 @@ export const RecordingActions = (props: { characters: Characters; recording: Rec
         return (
           <>
             Set
-            <VariableBlock name={"Current Stage"} />
+            <VariableBlock name={"Current Level"} />
             to
             <code>
               {beforeWorld.stages[a.value.constant] && beforeWorld.stages[a.value.constant].name}

--- a/frontend/src/editor/reducers/initial-state.ts
+++ b/frontend/src/editor/reducers/initial-state.ts
@@ -22,7 +22,7 @@ const InitialWorld: World = {
     },
     selectedStageId: {
       id: "selectedStageId",
-      name: "Current Stage",
+      name: "Current Level",
       value: stage.id,
       type: "stage",
     },

--- a/frontend/src/editor/reducers/tutorial/initial-state-stage-tutorial.ts
+++ b/frontend/src/editor/reducers/tutorial/initial-state-stage-tutorial.ts
@@ -2,7 +2,7 @@ import { Stage } from "../../../types";
 
 const Tutorial: Stage = {
   id: "5233a60cfd685f755e000002",
-  name: "Stage 1",
+  name: "Level 1",
   order: 1,
   actors: {
     1483668698770: {


### PR DESCRIPTION
## Summary
This PR updates terminology across the application by replacing all user-facing references to "Stage" with "Level" for improved clarity and consistency.

## Key Changes
- Updated home page tutorial and blank game option labels from "Tutorial Stage" and "Blank Stage" to "Tutorial Level" and "Blank Level"
- Changed modal header and action button text in the stages container from "Stages" and "Add Stage" to "Levels" and "Add Level"
- Updated stage switcher button tooltips and aria-labels from "Stage settings" to "Level settings"
- Renamed door character destination variable from "Destination Stage" to "Destination Level"
- Updated recording panel action display from "Current Stage" to "Current Level"
- Changed global state variable name from "Current Stage" to "Current Level"
- Updated tutorial initial state to use "Level 1" instead of "Stage 1"

## Implementation Details
The changes are purely cosmetic/UX improvements affecting user-visible text and labels. No functional logic or data structure changes were made. The internal variable names and IDs (like `selectedStageId`, `DOOR_VARIABLE_IDS.destinationStage`) remain unchanged to maintain backward compatibility with existing game data.

https://claude.ai/code/session_011iMgEoKsWViV4EUwoQEtF5