### PR TITLE
Update reset button styling and icon to use black color scheme

### DIFF
--- a/frontend/src/editor/components/stage/stage-controls.tsx
+++ b/frontend/src/editor/components/stage/stage-controls.tsx
@@ -78,16 +78,17 @@ const StageControls: React.FC<StageControlsProps> = ({
       <div style={{ flex: 1 }} />
 
       <div className={classNames("center transport-controls", { "is-playing": running })} data-tutorial-id="controls">
-        {/* Reset - green, farthest left: most change backward */}
+        {/* Reset - black like the clock, distinct from rewind: jumps back fast and stops */}
         {!readonly && (
           <Button
-            className="transport-btn transport-green"
+            className="transport-btn transport-black"
             disabled={world.history && world.history.length === 0}
             onClick={() => dispatch(rewindAllGameState(world.id))}
           >
             <svg width="18" height="18" viewBox="0 0 14 14" fill="currentColor">
               <rect x="0" y="1" width="2.5" height="12" />
-              <polygon points="12,1 12,13 3,7" />
+              <polygon points="8,1 8,13 3,7" />
+              <polygon points="13,1 13,13 8,7" />
             </svg>
           </Button>
         )}

--- a/frontend/src/editor/styles/editor.scss
+++ b/frontend/src/editor/styles/editor.scss
@@ -595,6 +595,10 @@ html {
         background-image: linear-gradient(#d42a2a, #a11e1e);
         color: white;
       }
+      &.transport-black.selected {
+        background-image: linear-gradient(#495057, #212529);
+        color: white;
+      }
     }
 
     .transport-green {
@@ -605,6 +609,9 @@ html {
     }
     .transport-red {
       color: #d42a2a;
+    }
+    .transport-black {
+      color: #495057;
     }
 
     .right {


### PR DESCRIPTION
## Summary
Updated the reset/rewind button in the stage controls to use a black color scheme instead of green, and modified its icon to display two triangles representing fast rewind and stop functionality.

## Key Changes
- Changed reset button class from `transport-green` to `transport-black`
- Updated button comment to clarify behavior: "jumps back fast and stops" rather than "most change backward"
- Modified the SVG icon to display two triangles:
  - First triangle moved from x=12 to x=8 (representing fast rewind)
  - Added second triangle at x=13 (representing stop)
- Added new `.transport-black.selected` style with dark gradient background (#495057 to #212529)
- Added new `.transport-black` color style (#495057) for the unselected state

## Implementation Details
The icon change uses two overlapping polygon triangles to visually represent the "rewind and stop" action, making the button's function more intuitive. The black color scheme distinguishes this reset action from other transport controls while maintaining visual consistency with the application's design system.

https://claude.ai/code/session_01GBY4i5sSxdnfwVRbhG6iLt