### PR TITLE
Fix off-by-one errors in image transformation coordinate calculations

### DIFF
--- a/frontend/src/editor/components/modal-paint/paint-model.ts
+++ b/frontend/src/editor/components/modal-paint/paint-model.ts
@@ -383,22 +383,22 @@ export class PaintModel {
 
   flipHorizontally(): void {
     const width = this.state.selectionImageData?.width ?? this.state.imageData?.width ?? 0;
-    this.applyCoordinateTransform(({ x, y }) => ({ x: width - x, y }));
+    this.applyCoordinateTransform(({ x, y }) => ({ x: width - 1 - x, y }));
   }
 
   flipVertically(): void {
     const height = this.state.selectionImageData?.height ?? this.state.imageData?.height ?? 0;
-    this.applyCoordinateTransform(({ x, y }) => ({ x, y: height - y }));
+    this.applyCoordinateTransform(({ x, y }) => ({ x, y: height - 1 - y }));
   }
 
   rotate90(): void {
     const width = this.state.selectionImageData?.width ?? this.state.imageData?.width ?? 0;
-    this.applyCoordinateTransform(({ x, y }) => ({ x: y, y: width - x }));
+    this.applyCoordinateTransform(({ x, y }) => ({ x: y, y: width - 1 - x }));
   }
 
   rotateNeg90(): void {
     const height = this.state.selectionImageData?.height ?? this.state.imageData?.height ?? 0;
-    this.applyCoordinateTransform(({ x, y }) => ({ x: height - y, y: x }));
+    this.applyCoordinateTransform(({ x, y }) => ({ x: height - 1 - y, y: x }));
   }
 
   // --- Anchor Square ---


### PR DESCRIPTION
## Summary
Fixed off-by-one errors in the coordinate transformation calculations for image flip and rotate operations in the paint model.

## Key Changes
- **flipHorizontally()**: Changed `width - x` to `width - 1 - x` to correctly map the rightmost pixel
- **flipVertically()**: Changed `height - y` to `height - 1 - y` to correctly map the bottom pixel
- **rotate90()**: Changed `width - x` to `width - 1 - x` in the y-coordinate calculation
- **rotateNeg90()**: Changed `height - y` to `height - 1 - y` in the x-coordinate calculation

## Implementation Details
These fixes ensure that pixel coordinates are correctly transformed when flipping or rotating images. The original formulas were treating dimensions as if coordinates ranged from 1 to N, when they actually range from 0 to N-1. By subtracting 1 from the dimension before subtracting the coordinate, the transformations now correctly map pixels to their intended positions.

https://claude.ai/code/session_01AKrutLmxaPS6BsnNXJvAUQ