### PR TITLE
Hide ignored positions during action playback in scenario stage

### DIFF
--- a/frontend/src/editor/components/inspector/scenario-stage.tsx
+++ b/frontend/src/editor/components/inspector/scenario-stage.tsx
@@ -49,13 +49,14 @@ export const ScenarioStage = React.memo(
             zIndex={characterZOrder.indexOf(actor.characterId)}
           />
         ))}
-        {extentIgnoredPositions(rule.extent).map(({ x, y }) => (
-          <RecordingIgnoredSprite
-            key={`ignored-${x}-${y}`}
-            x={x - xmin + 1}
-            y={y - ymin + 1}
-          />
-        ))}
+        {!applyActions &&
+          extentIgnoredPositions(rule.extent).map(({ x, y }) => (
+            <RecordingIgnoredSprite
+              key={`ignored-${x}-${y}`}
+              x={x - xmin + 1}
+              y={y - ymin + 1}
+            />
+          ))}
       </div>
     );
   },


### PR DESCRIPTION
## Summary
Modified the scenario stage inspector to conditionally render ignored position sprites only when not applying actions, preventing visual clutter during rule action playback.

## Changes
- Added `!applyActions` guard condition to the ignored positions rendering block in `ScenarioStage` component
- This ensures `RecordingIgnoredSprite` components are only displayed when the user is setting up the "before" state during rule recording, not during action demonstration/playback

## Implementation Details
The change wraps the `extentIgnoredPositions` map in a conditional that checks the `applyActions` flag. This aligns with the recording flow where:
1. User sets up "before" state (ignored positions visible)
2. User demonstrates "after" state by applying actions (ignored positions hidden to avoid visual interference)

This improves the UX during the programming-by-demonstration workflow by reducing visual noise when users are actively demonstrating rule actions.

https://claude.ai/code/session_01JGBKiJYnCoZkd9uTFoympq