### PR TITLE
Include characterZOrder in editor state initialization

### DIFF
--- a/frontend/src/editor/root-player.tsx
+++ b/frontend/src/editor/root-player.tsx
@@ -20,8 +20,8 @@ interface RootPlayerProps {
 export const RootPlayer = ({ world: gameWorld, editorStoreRef, immersive }: RootPlayerProps) => {
   const editorStore = useMemo(() => {
     const migrated = applyDataMigrations(gameWorld);
-    const { world, characters } = migrated.data;
-    const state = u({ world, characters }, initialState) as EditorState;
+    const { world, characters, characterZOrder } = migrated.data;
+    const state = u({ world, characters, characterZOrder }, initialState) as EditorState;
     const editorStore = configureStore(state);
     window.editorStore = editorStore;
     return editorStore;


### PR DESCRIPTION
## Summary
Updated the editor state initialization to include `characterZOrder` from the migrated game world data, ensuring the z-order state is properly preserved when loading worlds.

## Changes
- Added `characterZOrder` to the destructured data from `migrated.data`
- Included `characterZOrder` in the state update passed to `initialState`

## Details
The `characterZOrder` property is now properly initialized as part of the `EditorState` when a world is loaded. This ensures that character layering/z-order information is correctly restored from saved world data, maintaining visual stacking order consistency across editor sessions.

https://claude.ai/code/session_01Tuy5KEk1WMeE4rvemSB6xn