### PR TITLE
Improve sprite generation prompt with view perspective constraints

### DIFF
--- a/frontend/src/editor/components/modal-paint/paint-model.ts
+++ b/frontend/src/editor/components/modal-paint/paint-model.ts
@@ -533,7 +533,7 @@ export class PaintModel {
     const { imageData } = this.state;
     if (!imageData) return null;
 
-    const prompt = `Generate a pixel art sprite with a solid background based on the following description: ${description}`;
+    const prompt = `Generate a pixel art sprite with a solid background based on the following description: ${description}. The sprite must be drawn from a strict side view, top-down view, or front view only — never a diagonal, three-quarters, or isometric perspective, unless the description explicitly requests one of those views.`;
     try {
       const data = await makeRequest<{ imageUrl?: string; name?: string; error?: string }>(
         `/generate-sprite?prompt=${encodeURIComponent(prompt)}&width=${imageData.width}&height=${imageData.height}`,

--- a/frontend/src/editor/components/modal-paint/paint-model.ts
+++ b/frontend/src/editor/components/modal-paint/paint-model.ts
@@ -533,7 +533,7 @@ export class PaintModel {
     const { imageData } = this.state;
     if (!imageData) return null;
 
-    const prompt = `Generate a pixel art sprite with a solid background based on the following description: ${description}. The sprite must be drawn from a strict side view, top-down view, or front view only — never a diagonal, three-quarters, or isometric perspective, unless the description explicitly requests one of those views.`;
+    const prompt = `Generate a pixel art sprite with a solid background based on the following description: ${description}. The sprite should extend to the edges of the image, padding around the sprite is never desirable. The sprite must be drawn from a strict side view, top-down view, or front view only — never a diagonal, three-quarters, or isometric perspective, unless the description explicitly requests one of those views.`;
     try {
       const data = await makeRequest<{ imageUrl?: string; name?: string; error?: string }>(
         `/generate-sprite?prompt=${encodeURIComponent(prompt)}&width=${imageData.width}&height=${imageData.height}`,


### PR DESCRIPTION
## Summary
Enhanced the sprite generation prompt in the paint model to include explicit constraints on perspective views, ensuring generated pixel art sprites follow strict orthogonal perspectives (side, top-down, or front view) unless otherwise specified.

## Changes
- Updated the sprite generation prompt in `PaintModel.generateSprite()` to include detailed instructions about perspective constraints
- Added clarification that sprites should avoid diagonal, three-quarters, or isometric perspectives by default
- Allows users to explicitly request alternative perspectives in their descriptions if needed

## Details
The prompt enhancement helps the sprite generation AI produce more consistent and usable pixel art by constraining the output to standard orthogonal views. This is particularly important for grid-based game development where sprites need to align with the 2D grid-based stage system used throughout Codako.

https://claude.ai/code/session_01UNCVon2EVxaZMTduSYipoa