### PR TITLE
Handle undefined evaluatedRuleDetails in stage components

### DIFF
--- a/frontend/src/editor/components/stage/container.tsx
+++ b/frontend/src/editor/components/stage/container.tsx
@@ -23,10 +23,10 @@ import { Library } from "../library";
  */
 function getEvaluatedSquares(
   ruleId: string | null,
-  evaluatedRuleDetails: EvaluatedRuleDetailsMap,
+  evaluatedRuleDetails: EvaluatedRuleDetailsMap | undefined,
   selectedActors: UIState["selectedActors"],
 ): EvaluatedSquare[] {
-  if (!ruleId) {
+  if (!ruleId || !evaluatedRuleDetails) {
     return [];
   }
 
@@ -37,7 +37,7 @@ function getEvaluatedSquares(
     evalActorId = selectedActors.actorIds[0];
   } else {
     // Fall back: find any actor that has evaluation data for this rule
-    for (const actorId of Object.keys(evaluatedRuleDetails || {})) {
+    for (const actorId of Object.keys(evaluatedRuleDetails)) {
       if (evaluatedRuleDetails[actorId]?.[ruleId]) {
         evalActorId = actorId;
         break;

--- a/frontend/src/editor/components/stage/recording/panel-conditions.tsx
+++ b/frontend/src/editor/components/stage/recording/panel-conditions.tsx
@@ -23,10 +23,10 @@ import { makeId } from "../../../utils/utils";
  */
 function buildConditionStatusMap(
   ruleId: string | null,
-  evaluatedRuleDetails: EvaluatedRuleDetailsMap,
+  evaluatedRuleDetails: EvaluatedRuleDetailsMap | undefined,
   selectedActors: UIState["selectedActors"],
 ): { [conditionKey: string]: EvaluatedCondition } {
-  if (!ruleId) {
+  if (!ruleId || !evaluatedRuleDetails) {
     return {};
   }
 
@@ -37,7 +37,7 @@ function buildConditionStatusMap(
     evalActorId = selectedActors.actorIds[0];
   } else {
     // Fall back: find any actor that has evaluation data for this rule
-    for (const actorId of Object.keys(evaluatedRuleDetails || {})) {
+    for (const actorId of Object.keys(evaluatedRuleDetails)) {
       if (evaluatedRuleDetails[actorId]?.[ruleId]) {
         evalActorId = actorId;
         break;


### PR DESCRIPTION
## Summary
Updates type signatures and null-checking logic in stage components to properly handle cases where `evaluatedRuleDetails` may be `undefined`, improving type safety and preventing potential runtime errors.

## Key Changes
- Updated `evaluatedRuleDetails` parameter type from `EvaluatedRuleDetailsMap` to `EvaluatedRuleDetailsMap | undefined` in:
  - `getEvaluatedSquares()` in `container.tsx`
  - `buildConditionStatusMap()` in `panel-conditions.tsx`
- Added explicit `undefined` check alongside existing `ruleId` check in early return conditions
- Removed unnecessary fallback operator (`|| {}`) when iterating over `evaluatedRuleDetails` keys, since the undefined case is now handled by the early return

## Implementation Details
These changes ensure that both functions gracefully handle the case where rule evaluation data hasn't been computed yet, returning empty results rather than attempting to access properties on undefined values. The type signature now accurately reflects the actual possible values passed to these functions.

https://claude.ai/code/session_01VfVgUvi7NyEgfRzhB2UdF2