### PR TITLE
Adjust default actor position in transform editor preview

### DIFF
--- a/frontend/src/editor/components/inspector/transform-editor.tsx
+++ b/frontend/src/editor/components/inspector/transform-editor.tsx
@@ -78,7 +78,7 @@ export const TransformEditorModal = ({
               actor={{
                 id: "0",
                 variableValues: {},
-                position: { x: 3, y: 3 },
+                position: { x: 4, y: 4 },
                 appearance,
                 transform,
                 characterId,


### PR DESCRIPTION
## Summary
Updated the default preview actor position in the TransformEditorModal from (3, 3) to (4, 4) to better center the preview visualization on the grid.

## Changes
- Modified the default `position` values in the actor mock object used for transform editor previews from `{ x: 3, y: 3 }` to `{ x: 4, y: 4 }`

## Details
This change affects the transform editor's preview rendering, which displays how character transformations (position, appearance, etc.) will appear. The adjusted coordinates provide better visual centering for the preview actor on the grid display.

https://claude.ai/code/session_016gXyYPtPqcmt6jdGYBqKGq