### PR TITLE
Remove unused RECORDING_PHASE enum

### DIFF
--- a/frontend/src/editor/components/stage/container.tsx
+++ b/frontend/src/editor/components/stage/container.tsx
@@ -11,7 +11,6 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import * as Types from "../../../types";
 import { EvaluatedRuleDetailsMap, EvaluatedSquare, UIState } from "../../../types";
 import { useEditorSelector } from "../../../hooks/redux";
-import { RECORDING_PHASE } from "../../constants/constants";
 import { collectDoorsByDestinationStage } from "../../utils/door-constants";
 import { getCurrentStageForWorld } from "../../utils/selectors";
 import { Library } from "../library";
@@ -69,54 +68,52 @@ const StageContainer = ({ readonly, immersive }: { readonly?: boolean; immersive
     controls = (
       <StageRecordingControls characters={characters} dispatch={dispatch} recording={recording} />
     );
-    if (recording.phase === RECORDING_PHASE.RECORD) {
-      const evaluatedSquares = getEvaluatedSquares(
-        recording.ruleId,
-        world.evaluatedRuleDetails,
-        selectedActors,
-      );
+    const evaluatedSquares = getEvaluatedSquares(
+      recording.ruleId,
+      world.evaluatedRuleDetails,
+      selectedActors,
+    );
 
-      stageA = (
+    stageA = (
+      <Stage
+        style={{ marginRight: 2 }}
+        world={recording.beforeWorld}
+        stage={getCurrentStageForWorld(recording.beforeWorld)!}
+        recordingExtent={recording.extent}
+        recordingCentered
+        evaluatedSquares={evaluatedSquares}
+        interactionMode="full"
+      />
+    );
+    if (recording.actions !== null) {
+      stageB = (
         <Stage
-          style={{ marginRight: 2 }}
-          world={recording.beforeWorld}
-          stage={getCurrentStageForWorld(recording.beforeWorld)!}
+          style={{ marginLeft: 2 }}
+          world={recording.afterWorld}
+          stage={getCurrentStageForWorld(recording.afterWorld)!}
           recordingExtent={recording.extent}
           recordingCentered
-          evaluatedSquares={evaluatedSquares}
-          interactionMode="full"
         />
       );
-      if (recording.actions !== null) {
-        stageB = (
-          <Stage
-            style={{ marginLeft: 2 }}
-            world={recording.afterWorld}
-            stage={getCurrentStageForWorld(recording.afterWorld)!}
-            recordingExtent={recording.extent}
-            recordingCentered
-          />
-        );
-      }
-      actions = (
-        <div className="recording-specifics">
-          <div
-            style={{
-              position: "absolute",
-              zIndex: 2,
-              transform: "translate(0, -100%)",
-              paddingBottom: 5,
-            }}
-          >
-            <StageRecordingTools />
-          </div>
-          <RecordingConditions characters={characters} recording={recording} />
-          {recording.actions !== null && (
-            <RecordingActions characters={characters} recording={recording} />
-          )}
-        </div>
-      );
     }
+    actions = (
+      <div className="recording-specifics">
+        <div
+          style={{
+            position: "absolute",
+            zIndex: 2,
+            transform: "translate(0, -100%)",
+            paddingBottom: 5,
+          }}
+        >
+          <StageRecordingTools />
+        </div>
+        <RecordingConditions characters={characters} recording={recording} />
+        {recording.actions !== null && (
+          <RecordingActions characters={characters} recording={recording} />
+        )}
+      </div>
+    );
   }
 
   /**

--- a/frontend/src/editor/components/stage/stage-recording-controls.tsx
+++ b/frontend/src/editor/components/stage/stage-recording-controls.tsx
@@ -4,7 +4,6 @@ import { Dispatch } from "redux";
 
 import { makeRequest } from "../../../helpers/api";
 import { cancelRecording, finishRecording } from "../../actions/recording-actions";
-import { RECORDING_PHASE } from "../../constants/constants";
 import { getCurrentStageForWorld } from "../../utils/selectors";
 import { Actor, Characters, RecordingState, RuleAction, RuleCondition, Stage } from "../../../types";
 
@@ -185,54 +184,41 @@ const StageRecordingControls: React.FC<StageRecordingControlsProps> = ({
   };
 
   const onNext = async () => {
-    if (recording.phase === RECORDING_PHASE.RECORD) {
-      let generatedName = "Untitled Rule";
+    let generatedName = "Untitled Rule";
 
-      try {
-        const payload = buildNamingPayload(recording, characters);
+    try {
+      const payload = buildNamingPayload(recording, characters);
 
-        console.log("Payload:", payload);
+      console.log("Payload:", payload);
 
-        const resp = (await makeRequest("/generate-rule-name", {
-          method: "POST",
-          json: { recording: payload },
-        })) as { name?: string } | null;
-        if (resp && resp.name) {
-          generatedName = resp.name;
-          console.log("Suggested rule name:", generatedName);
-        }
-      } catch (err) {
-        console.error("Failed to auto-generate rule name:", err);
+      const resp = (await makeRequest("/generate-rule-name", {
+        method: "POST",
+        json: { recording: payload },
+      })) as { name?: string } | null;
+      if (resp && resp.name) {
+        generatedName = resp.name;
+        console.log("Suggested rule name:", generatedName);
       }
-
-      dispatch(finishRecording(generatedName));
+    } catch (err) {
+      console.error("Failed to auto-generate rule name:", err);
     }
-  };
 
-  const { phase } = recording;
-
-  const message: Record<string, string> = {
-    [RECORDING_PHASE.RECORD]:
-      "Use the handles to expand the frame and act out what you want to happen in the picture on the right.",
-  };
-
-  const next: Record<string, React.ReactNode> = {
-    [RECORDING_PHASE.RECORD]: (
-      <span>
-        <i className="fa fa-checkmark" />{" "}
-        Done
-      </span>
-    ),
+    dispatch(finishRecording(generatedName));
   };
 
   return (
     <div className="stage-controls">
-      <div className="left message">{message[phase]}</div>
+      <div className="left message">
+        Use the handles to expand the frame and act out what you want to happen in the picture on
+        the right.
+      </div>
       <div style={{ flex: 1 }} />
       <div className="right">
         <Button onClick={onCancel}>Cancel</Button>{" "}
         <Button data-tutorial-id="record-next-step" color="success" onClick={onNext}>
-          {next[phase]}
+          <span>
+            <i className="fa fa-checkmark" /> Done
+          </span>
         </Button>{" "}
       </div>
     </div>

--- a/frontend/src/editor/constants/constants.ts
+++ b/frontend/src/editor/constants/constants.ts
@@ -34,7 +34,3 @@ export enum TOOLS {
   IGNORE_SQUARE = "ignore-square",
   ADD_CLICK_CONDITION = "add-click-condition",
 }
-
-export enum RECORDING_PHASE {
-  RECORD = "record",
-}

--- a/frontend/src/editor/constants/tutorial-content.ts
+++ b/frontend/src/editor/constants/tutorial-content.ts
@@ -17,7 +17,7 @@ import { stopPlayback } from "../actions/ui-actions";
 import { TutorialAnnotationProps } from "../components/tutorial/annotation";
 import { PoseKey } from "../components/tutorial/girl";
 import { getCurrentStageForWorld } from "../utils/selectors";
-import { RECORDING_PHASE, TOOLS } from "./constants";
+import { TOOLS } from "./constants";
 
 export const poseFrames = {
   "sitting-looking": ["sitting-looking"],
@@ -537,7 +537,6 @@ export const baseTutorialContent: TutorialStepContent[] = [
       stateMatching: (state) => {
         return (
           state.ui.selectedToolId === TOOLS.RECORD &&
-          state.recording.phase === RECORDING_PHASE.RECORD &&
           state.recording.characterId === "oou4u6jemi"
         );
       },
@@ -624,7 +623,6 @@ export const baseTutorialContent: TutorialStepContent[] = [
       stateMatching: (state) => {
         return (
           state.ui.selectedToolId === TOOLS.RECORD &&
-          state.recording.phase === RECORDING_PHASE.RECORD &&
           state.recording.characterId === "oou4u6jemi"
         );
       },

--- a/frontend/src/editor/reducers/initial-state.ts
+++ b/frontend/src/editor/reducers/initial-state.ts
@@ -1,5 +1,5 @@
 import { EditorState, World } from "../../types";
-import { RECORDING_PHASE, TOOLS, WORLDS } from "../constants/constants";
+import { TOOLS, WORLDS } from "../constants/constants";
 import stage from "./initial-state-stage";
 
 const InitialWorld: World = {
@@ -84,7 +84,6 @@ const InitialState: EditorState = {
     },
   },
   recording: {
-    phase: RECORDING_PHASE.RECORD,
     characterId: null,
     actorId: null,
     ruleId: null,

--- a/frontend/src/editor/reducers/recording-reducer.ts
+++ b/frontend/src/editor/reducers/recording-reducer.ts
@@ -19,7 +19,7 @@ import {
   getAfterWorldForRecording,
   offsetForEditingRule,
 } from "../components/stage/recording/utils";
-import { RECORDING_PHASE, WORLDS } from "../constants/constants";
+import { WORLDS } from "../constants/constants";
 import { defaultAppearanceId } from "../utils/character-helpers";
 import { extentByShiftingExtent } from "../utils/recording-helpers";
 import { getCurrentStageForWorld } from "../utils/selectors";
@@ -27,7 +27,6 @@ import { actorFilledPoints } from "../utils/stage-helpers";
 import WorldOperator from "../utils/world-operator";
 
 function stateForEditingRule(
-  phase: RECORDING_PHASE,
   rule: Rule | RuleTreeFlowItemCheck,
   entireState: EditorState,
 ) {
@@ -37,7 +36,6 @@ function stateForEditingRule(
   return {
     ruleId: rule.id,
     characterId: rule.actors[rule.mainActorId].characterId,
-    phase: phase,
     actorId: rule.mainActorId,
     conditions: u.constant(rule.conditions),
     actions: "actions" in rule ? u.constant(rule.actions) : u.constant(null),
@@ -108,7 +106,6 @@ function recordingReducer(
         {
           ruleId: null,
           characterId: actor.characterId,
-          phase: RECORDING_PHASE.RECORD,
           actorId: actor.id,
           actions: u.constant([]),
           conditions: u.constant([
@@ -154,10 +151,10 @@ function recordingReducer(
           },
         },
       };
-      return u(stateForEditingRule(RECORDING_PHASE.RECORD, initialRule, entireState), nextState);
+      return u(stateForEditingRule(initialRule, entireState), nextState);
     }
     case Types.EDIT_RULE_RECORDING: {
-      return u(stateForEditingRule(RECORDING_PHASE.RECORD, action.rule, entireState), nextState);
+      return u(stateForEditingRule(action.rule, entireState), nextState);
     }
     case Types.SETUP_CHECK_RECORDING_FOR_ACTOR: {
       // Initial creation of a precondition check with a selected actor on the
@@ -171,7 +168,6 @@ function recordingReducer(
           {
             ruleId: action.check.id,
             characterId: actor.characterId,
-            phase: RECORDING_PHASE.RECORD,
             actorId: actor.id,
             actions: u.constant(null),
             conditions: u.constant([
@@ -196,10 +192,7 @@ function recordingReducer(
         );
       }
       // Fallback: if actor not found, use the standard editing path
-      return u(
-        stateForEditingRule(RECORDING_PHASE.RECORD, action.check, entireState),
-        nextState,
-      );
+      return u(stateForEditingRule(action.check, entireState), nextState);
     }
     case Types.FINISH_RECORDING: {
       return Object.assign({}, initialState.recording);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,4 +1,4 @@
-import { RECORDING_PHASE, TOOLS, WORLDS } from "./editor/constants/constants";
+import { TOOLS, WORLDS } from "./editor/constants/constants";
 import { Frame } from "./editor/utils/frame-accumulator";
 
 export type ImageData = string;
@@ -431,7 +431,6 @@ export type Game = {
 };
 
 export type RecordingState = {
-  phase: RECORDING_PHASE;
   characterId: string | null;
   actorId: string | null;
   ruleId: string | null;


### PR DESCRIPTION
## Summary
Removes the `RECORDING_PHASE` enum and all references to it throughout the codebase. The enum only contained a single `RECORD` value that was used as a conditional check, but the recording system always operates in this state, making the check redundant.

## Changes
- **Removed enum definition** from `frontend/src/editor/constants/constants.ts`
- **Simplified recording logic** in `frontend/src/editor/components/stage/container.tsx` by removing the `if (recording.phase === RECORDING_PHASE.RECORD)` conditional and unindenting the contained code
- **Simplified UI controls** in `frontend/src/editor/components/stage/stage-recording-controls.tsx` by removing phase-based message and button text mapping, replacing with static content
- **Updated reducer** in `frontend/src/editor/reducers/recording-reducer.ts`:
  - Removed `phase` parameter from `stateForEditingRule()` function
  - Removed `phase` field initialization from recording state
- **Updated initial state** in `frontend/src/editor/reducers/initial-state.ts` to remove `phase` field
- **Updated type definition** in `frontend/src/types.ts` to remove `phase` field from `RecordingState`
- **Updated imports** in `frontend/src/editor/constants/tutorial-content.ts` and removed phase checks from tutorial state matching conditions

## Implementation Details
The recording system was checking `recording.phase === RECORDING_PHASE.RECORD` in multiple places, but since the enum only had one value and the recording state always operates in this mode, these checks were always true. Removing the enum and its checks simplifies the code without changing behavior.

https://claude.ai/code/session_01BvMtYDfL2SBuWbWVVN27vX