### PR TITLE
Fix actor sprite positioning in selection popover

### DIFF
--- a/frontend/src/editor/components/stage/actor-selection-popover.tsx
+++ b/frontend/src/editor/components/stage/actor-selection-popover.tsx
@@ -87,13 +87,19 @@ const ActorSelectionPopover: React.FC<ActorSelectionPopoverProps> = ({
                 overflow: "hidden",
               }}
             >
-              <div style={{ position: "relative" }}>
+              <div
+                style={{
+                  position: "relative",
+                  width: bounds.width * STAGE_CELL_SIZE,
+                  height: bounds.height * STAGE_CELL_SIZE,
+                }}
+              >
                 <ActorSprite
                   character={character}
-                  // The container is sized to bounds.width x bounds.height. The
-                  // ActorSprite renderer treats position as 1-indexed Y-up, so
-                  // shift the bounds offset (which is a Y-down "from top" cell
-                  // shift) into 1-indexed Y-up world coords for this container.
+                  // The wrapper is sized to bounds.width x bounds.height cells,
+                  // and ActorSprite positions itself via CSS `bottom` in Y-up
+                  // 1-indexed world coords. Shift the bounds offset (a Y-down
+                  // "from top" cell shift) into Y-up coords within the wrapper.
                   actor={{
                     ...actor,
                     position: {


### PR DESCRIPTION
## Summary
Fixed the actor sprite positioning in the selection popover by explicitly sizing the wrapper container and clarifying the coordinate system transformation in comments.

## Changes
- Added explicit width and height to the sprite wrapper div, calculated as `bounds.width/height * STAGE_CELL_SIZE` to properly contain the rendered sprite
- Updated comments to clarify that the wrapper is sized in cells and that ActorSprite positions itself via CSS `bottom` property in Y-up 1-indexed world coordinates
- Improved comment clarity around the coordinate system transformation from Y-down (bounds offset) to Y-up (world coords)

## Implementation Details
The wrapper container now has explicit dimensions matching the actor's bounding box in pixels, ensuring the sprite renders within the expected bounds. The coordinate transformation logic remains unchanged—this is purely a sizing and documentation fix to make the positioning behavior more explicit and maintainable.

https://claude.ai/code/session_019jwZNERzhV3KkakVPXhG76