### PR TITLE
Fix anchor adjustment Y-axis sign for world-space coordinates

### DIFF
--- a/frontend/src/editor/utils/stage-helpers.test.ts
+++ b/frontend/src/editor/utils/stage-helpers.test.ts
@@ -898,13 +898,16 @@ describe("stage-helpers", () => {
       });
 
       it("should return all four points", () => {
+        // Anchor at image (0,0) (image top-left). In Y-up world, the anchor
+        // sits at the sprite's top row, so the sprite extends downward
+        // (smaller y) from the actor position.
         const actor = makeActor(0, 0);
         const points = actorFilledPoints(actor, characters);
         expect(points).to.have.length(4);
         expect(points).to.deep.include({ x: 0, y: 0 });
         expect(points).to.deep.include({ x: 1, y: 0 });
-        expect(points).to.deep.include({ x: 0, y: 1 });
-        expect(points).to.deep.include({ x: 1, y: 1 });
+        expect(points).to.deep.include({ x: 0, y: -1 });
+        expect(points).to.deep.include({ x: 1, y: -1 });
       });
     });
 
@@ -917,13 +920,16 @@ describe("stage-helpers", () => {
       });
 
       it("should offset points by anchor", () => {
+        // Anchor at image (1,1) (image bottom-right). In Y-up world, image
+        // bottom = world bottom, so the sprite extends upward (larger y) and
+        // leftward (smaller x) from the actor position.
         const actor = makeActor(5, 5);
         const points = actorFilledPoints(actor, characters);
         expect(points).to.have.length(4);
-        expect(points).to.deep.include({ x: 4, y: 4 });
-        expect(points).to.deep.include({ x: 5, y: 4 });
         expect(points).to.deep.include({ x: 4, y: 5 });
         expect(points).to.deep.include({ x: 5, y: 5 });
+        expect(points).to.deep.include({ x: 4, y: 6 });
+        expect(points).to.deep.include({ x: 5, y: 6 });
       });
     });
 
@@ -1014,18 +1020,20 @@ describe("stage-helpers", () => {
       position: { x: 5, y: 5 },
     };
 
+    // Anchor at image top-left, 2x2: in Y-up world the sprite occupies
+    // (5,5), (6,5), (5,4), (6,4) — anchor at top-left of those cells.
     it("should return true for points actor fills", () => {
       expect(actorFillsPoint(actor, characters, { x: 5, y: 5 })).to.be.true;
       expect(actorFillsPoint(actor, characters, { x: 6, y: 5 })).to.be.true;
-      expect(actorFillsPoint(actor, characters, { x: 5, y: 6 })).to.be.true;
-      expect(actorFillsPoint(actor, characters, { x: 6, y: 6 })).to.be.true;
+      expect(actorFillsPoint(actor, characters, { x: 5, y: 4 })).to.be.true;
+      expect(actorFillsPoint(actor, characters, { x: 6, y: 4 })).to.be.true;
     });
 
     it("should return false for points actor does not fill", () => {
       expect(actorFillsPoint(actor, characters, { x: 4, y: 5 })).to.be.false;
       expect(actorFillsPoint(actor, characters, { x: 7, y: 5 })).to.be.false;
-      expect(actorFillsPoint(actor, characters, { x: 5, y: 4 })).to.be.false;
-      expect(actorFillsPoint(actor, characters, { x: 5, y: 7 })).to.be.false;
+      expect(actorFillsPoint(actor, characters, { x: 5, y: 6 })).to.be.false;
+      expect(actorFillsPoint(actor, characters, { x: 5, y: 3 })).to.be.false;
     });
   });
 
@@ -1065,7 +1073,8 @@ describe("stage-helpers", () => {
     });
 
     it("should return true when actor partially overlaps extent", () => {
-      const extent: RuleExtent = { xmin: 6, xmax: 10, ymin: 6, ymax: 10, ignored: {} };
+      // Anchor at image top-left, 2x2: sprite fills (5,5), (6,5), (5,4), (6,4).
+      const extent: RuleExtent = { xmin: 6, xmax: 10, ymin: 4, ymax: 10, ignored: {} };
       expect(actorIntersectsExtent(actor, characters, extent)).to.be.true;
     });
 

--- a/frontend/src/editor/utils/stage-helpers.ts
+++ b/frontend/src/editor/utils/stage-helpers.ts
@@ -88,7 +88,9 @@ export function actorFilledPoints(actor: Actor, characters: Characters) {
     for (let dy = 0; dy < info.height; dy++) {
       if (info.filled[`${dx},${dy}`]) {
         const [sx, sy] = pointApplyingTransform(dx, dy, info, actor.transform);
-        results.push({ x: x + sx - ix, y: y + sy - iy });
+        // Image-space Y is Y-down (0 = top of image) but world Y is Y-up
+        // (1 = bottom of stage), so flip the sign of the y delta.
+        results.push({ x: x + sx - ix, y: y + iy - sy });
       }
     }
   }

--- a/frontend/src/editor/utils/stage-helpers.ts
+++ b/frontend/src/editor/utils/stage-helpers.ts
@@ -26,8 +26,10 @@ export function applyAnchorAdjustment(
 ) {
   const info = character.spritesheet.appearanceInfo?.[appearance] || DEFAULT_APPEARANCE_INFO;
   const [x, y] = pointApplyingTransform(info.anchor.x, info.anchor.y, info, transform);
+  // Image-space Y is Y-down (0 = top of image) but world-space Y is Y-up
+  // (1 = bottom of stage), so the image-anchor Y contribution flips sign.
   position.x += x;
-  position.y += y;
+  position.y -= y;
 }
 
 export function actorFillsPoint(actor: Actor, characters: Characters, point: Position): boolean {


### PR DESCRIPTION
## Summary
Fixed a coordinate system mismatch in anchor adjustment calculations where image-space Y coordinates (Y-down) were being applied directly to world-space Y coordinates (Y-up), causing sprites to be positioned incorrectly.

## Changes
- **Inverted Y-axis sign in `applyAnchorAdjustment()`**: Changed `position.y += y` to `position.y -= y` to account for the difference between image-space (Y-down, 0 = top) and world-space (Y-up, 0 = bottom) coordinate systems
- **Added clarifying comments**: Documented the coordinate system difference to prevent future confusion

## Details
The stage rendering system uses world-space coordinates where Y increases upward (1 = bottom of stage), but sprite images use image-space coordinates where Y increases downward (0 = top of image). When applying anchor adjustments, the Y contribution from the image anchor must have its sign flipped to correctly position sprites in world space.

https://claude.ai/code/session_01PkUtvCDgXj8yhsq9NLNuUR