### PR TITLE
Reset to pointer tool after painting an appearance from the stage

### DIFF
--- a/frontend/src/editor/components/stage/stage.tsx
+++ b/frontend/src/editor/components/stage/stage.tsx
@@ -785,6 +785,7 @@ export const Stage = ({
       case TOOLS.PAINT:
         if (!showPopoverIfOverlapping(TOOLS.PAINT)) {
           dispatch(paintCharacterAppearance(actor.characterId, actor.appearance));
+          dispatch(selectToolId(TOOLS.POINTER));
         }
         handled = true;
         break;
@@ -1045,6 +1046,7 @@ export const Stage = ({
     switch (toolId) {
       case TOOLS.PAINT:
         dispatch(paintCharacterAppearance(actor.characterId, actor.appearance));
+        dispatch(selectToolId(TOOLS.POINTER));
         break;
       case TOOLS.STAMP:
         dispatch(selectToolItem(selFor([actor.id])));


### PR DESCRIPTION
The paint tool reset to pointer when clicking characters/appearances in the library but not when clicking actors on the stage (either directly or via the actor selection popover). Match the library behavior so the paint tool consistently deactivates after one use.