### PR TITLE
Fix Y-axis sign in offsetForEditingRule

### DIFF
--- a/frontend/src/editor/components/stage/recording/utils.tsx
+++ b/frontend/src/editor/components/stage/recording/utils.tsx
@@ -23,7 +23,10 @@ export function offsetForEditingRule(extent: RuleExtent, world: WorldMinimal) {
   const ey = extent.ymax - extent.ymin;
   return {
     x: Math.round(stage!.width / 2 + ex / 2),
-    y: Math.round(stage!.height / 2 + ey / 2),
+    // Y-up world: ymax is the visual top of the extent. Subtract ey/2 so the
+    // shifted extent sits in the lower half of the stage (where the previous
+    // Y-down formula `+ ey/2` placed it before the coordinate flip).
+    y: Math.round(stage!.height / 2 - ey / 2),
   };
 }
 


### PR DESCRIPTION
## Summary

When you open the recording editor for an existing rule, the initial `recordingExtent` was shifted in the wrong direction on the Y axis after the Y-up migration. The rule's extent ended up above the stage center instead of below it.

The culprit is `offsetForEditingRule` in `frontend/src/editor/components/stage/recording/utils.tsx`. Its Y formula was written for Y-down semantics:

```ts
y: Math.round(stage!.height / 2 + ey / 2),
```

In old Y-down, `ymax > ymin` meant `ymax` was the *bottom* of the extent, and adding `ey/2` shifted the extent so its bottom edge sat near the middle of the stage — visually below center.

After the Y-up flip, `ymax` is now the *top* of the extent, so the same `+ ey/2` shifts the top edge to mid-stage and the extent ends up above center. Flipping the sign restores the original visual placement:

```ts
y: Math.round(stage!.height / 2 - ey / 2),
```

X is unchanged because image X and world X both increase left→right.

## Test plan

- [x] `yarn test` — all 305 tests pass
- [x] `yarn lint` — clean (only pre-existing warnings)
- [ ] Manual: open an existing multi-row rule for editing; verify the rule's extent overlay appears in the lower half of the stage (matching pre-Y-up behavior) instead of the upper half

Follow-up to #143.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkUtvCDgXj8yhsq9NLNuUR)_