### PR TITLE
Implement teleport action for door-based actor movement

### DIFF
--- a/frontend/src/editor/components/stage/recording/panel-actions.tsx
+++ b/frontend/src/editor/components/stage/recording/panel-actions.tsx
@@ -95,6 +95,22 @@ export const RecordingActions = (props: { characters: Characters; recording: Rec
           </>
         );
       }
+      if (a.type === "teleport") {
+        const door = beforeStage.actors[a.doorActorId];
+        const doorCharacter = door ? characters[door.characterId] : undefined;
+        return (
+          <>
+            Teleport
+            <ActorBlock actor={actor} character={character} />
+            through
+            {door && doorCharacter ? (
+              <ActorBlock actor={door} character={doorCharacter} />
+            ) : (
+              <code>door</code>
+            )}
+          </>
+        );
+      }
 
       if (a.type === "variable") {
         return (

--- a/frontend/src/editor/reducers/recording-reducer.ts
+++ b/frontend/src/editor/reducers/recording-reducer.ts
@@ -5,6 +5,7 @@ import worldReducer from "./world-reducer";
 
 import {
   Actor,
+  Characters,
   EditorState,
   RecordingState,
   Rule,
@@ -86,7 +87,7 @@ function recordingReducer(
     // Normally, rule actions are appended to the list of actions in the rule, but
     // if you modify a var or global you've already modified in the rule, the new
     // action replaces it. There isn't any value in intra-rule changes.
-    const recordingActions = buildActionsFromStageActions(state, action);
+    const recordingActions = buildActionsFromStageActions(state, action, characters);
     if (recordingActions) {
       nextState.actions = [
         ...nextState.actions.filter(
@@ -267,13 +268,23 @@ function recordingReducer(
 function buildActionsFromStageActions(
   { actorId, beforeWorld, afterWorld }: RecordingState,
   action: Actions,
+  characters: Characters,
 ): RuleAction[] | null {
-  const mainActorBeforePosition = getCurrentStageForWorld(beforeWorld)!.actors[actorId!].position;
+  const beforeStage = getCurrentStageForWorld(beforeWorld)!;
+  const mainActorBeforePosition = beforeStage.actors[actorId!].position;
+
+  const doorActorAtPosition = (x: number, y: number): Actor | null => {
+    for (const a of Object.values(beforeStage.actors)) {
+      if (a.position.x !== x || a.position.y !== y) continue;
+      if (characters[a.characterId]?.kind === "door") return a;
+    }
+    return null;
+  };
 
   switch (action.type) {
     case Types.UPSERT_ACTORS: {
       return action.upserts
-        .map(({ id: actorId, values }): RuleAction | null => {
+        .flatMap(({ id: actorId, values }): RuleAction | RuleAction[] | null => {
           const existing = afterWorld && getCurrentStageForWorld(afterWorld)?.actors[actorId];
           if (!existing) {
             return {
@@ -291,7 +302,7 @@ function buildActionsFromStageActions(
             if (pos.x === existing.position.x && pos.y === existing.position.y) {
               return null;
             }
-            return {
+            const moveAction: RuleAction = {
               type: "move",
               actorId: actorId,
               offset: {
@@ -299,6 +310,14 @@ function buildActionsFromStageActions(
                 y: pos.y! - mainActorBeforePosition.y,
               },
             };
+            const door = doorActorAtPosition(pos.x!, pos.y!);
+            if (door && door.id !== actorId) {
+              return [
+                moveAction,
+                { type: "teleport", actorId, doorActorId: door.id },
+              ];
+            }
+            return moveAction;
           }
           if ("variableValues" in values) {
             const [key, value] = Object.entries(values.variableValues || {})[0];

--- a/frontend/src/editor/utils/world-operator.ts
+++ b/frontend/src/editor/utils/world-operator.ts
@@ -52,6 +52,7 @@ export default function WorldOperator(previousWorld: WorldMinimal, characters: C
   let input: FrameInput;
   let evaluatedRuleDetails: EvaluatedRuleDetailsMap = {};
   let frameAccumulator: FrameAccumulator;
+  let crossStageActorsForDestStage: { [destStageId: string]: { [actorId: string]: Actor } } = {};
 
   function wrappedPosition({ x, y }: PositionRelativeToWorld) {
     // World coordinates are 1-indexed (bottom-left = (1, 1)). Wrap relative to
@@ -508,6 +509,9 @@ export default function WorldOperator(previousWorld: WorldMinimal, characters: C
           if ("actorId" in action && rule.actors[action.actorId]) {
             requiredActorIds.push(action.actorId);
           }
+          if (action.type === "teleport" && rule.actors[action.doorActorId]) {
+            requiredActorIds.push(action.doorActorId);
+          }
         }
       }
       for (const { left, right } of rule.conditions) {
@@ -601,6 +605,45 @@ export default function WorldOperator(previousWorld: WorldMinimal, characters: C
                 animationStyle: action.animationStyle,
               });
             }
+          } else if (action.type === "teleport") {
+            const door = stageActorForId[action.doorActorId];
+            if (!door) {
+              return;
+            }
+            const doorCharacter = characters[door.characterId];
+            if (doorCharacter?.kind !== "door") {
+              return;
+            }
+            const destXStr = getVariableValue(door, doorCharacter, DOOR_VARIABLE_IDS.destinationX, "=");
+            const destYStr = getVariableValue(door, doorCharacter, DOOR_VARIABLE_IDS.destinationY, "=");
+            const destStageRaw =
+              getVariableValue(door, doorCharacter, DOOR_VARIABLE_IDS.destinationStage, "=") ?? "";
+
+            const destX = Number(destXStr);
+            const destY = Number(destYStr);
+            if (!Number.isFinite(destX) || !Number.isFinite(destY)) {
+              return;
+            }
+            const destStageId = destStageRaw || stage.id;
+
+            if (destStageId === stage.id) {
+              stageActor.position = { x: destX, y: destY };
+              frameAccumulator?.push({ ...stageActor, actionIdx, animationStyle: "none" });
+            } else {
+              const destStage = previousWorld.stages[destStageId];
+              if (!destStage) {
+                return;
+              }
+              crossStageActorsForDestStage[destStageId] =
+                crossStageActorsForDestStage[destStageId] ?? deepClone(destStage.actors);
+              const teleported: Actor = {
+                ...stageActor,
+                position: { x: destX, y: destY },
+              };
+              crossStageActorsForDestStage[destStageId][stageActor.id] = teleported;
+              delete actors[stageActor.id];
+              delete stageActorForId[action.actorId];
+            }
           } else if (action.type === "delete") {
             delete actors[stageActor.id];
             if (action.animationStyle !== "skip") {
@@ -685,66 +728,6 @@ export default function WorldOperator(previousWorld: WorldMinimal, characters: C
     };
   }
 
-  function applyDoorTeleports(): { [destStageId: string]: { [actorId: string]: Actor } } {
-    const crossStageActorsForDestStage: { [destStageId: string]: { [actorId: string]: Actor } } =
-      {};
-
-    // Identify door actors present on the Current Level. Cache their destinations
-    // so we don't re-read variable values for each mover.
-    type DoorInfo = { destX: number; destY: number; destStageId: string };
-    const doorsByPosKey: { [posKey: string]: DoorInfo } = {};
-    for (const a of Object.values(actors)) {
-      const character = characters[a.characterId];
-      if (character?.kind !== "door") continue;
-
-      const destXStr = getVariableValue(a, character, DOOR_VARIABLE_IDS.destinationX, "=");
-      const destYStr = getVariableValue(a, character, DOOR_VARIABLE_IDS.destinationY, "=");
-      const destStageRaw =
-        getVariableValue(a, character, DOOR_VARIABLE_IDS.destinationStage, "=") ?? "";
-
-      const destX = Number(destXStr);
-      const destY = Number(destYStr);
-      if (!Number.isFinite(destX) || !Number.isFinite(destY)) continue;
-
-      const destStageId = destStageRaw || stage.id;
-      doorsByPosKey[`${a.position.x},${a.position.y}`] = { destX, destY, destStageId };
-    }
-
-    if (Object.keys(doorsByPosKey).length === 0) {
-      return crossStageActorsForDestStage;
-    }
-
-    // Teleport any non-door actor sitting on a door. Doors don't teleport themselves,
-    // and we only apply one teleport per actor per tick to avoid within-tick chains.
-    for (const mover of Object.values(actors)) {
-      const moverCharacter = characters[mover.characterId];
-      if (moverCharacter?.kind === "door") continue;
-
-      const door = doorsByPosKey[`${mover.position.x},${mover.position.y}`];
-      if (!door) continue;
-
-      if (door.destStageId === stage.id) {
-        mover.position = { x: door.destX, y: door.destY };
-        frameAccumulator?.push({ ...mover, animationStyle: "none" });
-      } else {
-        const destStage = previousWorld.stages[door.destStageId];
-        if (!destStage) continue;
-
-        crossStageActorsForDestStage[door.destStageId] =
-          crossStageActorsForDestStage[door.destStageId] ?? deepClone(destStage.actors);
-
-        const teleported: Actor = {
-          ...mover,
-          position: { x: door.destX, y: door.destY },
-        };
-        crossStageActorsForDestStage[door.destStageId][mover.id] = teleported;
-        delete actors[mover.id];
-      }
-    }
-
-    return crossStageActorsForDestStage;
-  }
-
   function resetForRule(
     rule: Rule | RuleTreeFlowItemCheck,
     { offset, applyActions }: { offset: Position; applyActions: boolean },
@@ -782,6 +765,7 @@ export default function WorldOperator(previousWorld: WorldMinimal, characters: C
     }
 
     frameAccumulator = new FrameAccumulator(actors);
+    crossStageActorsForDestStage = {};
 
     // lay out the before state and apply any rules that apply to
     // the actors currently on the board
@@ -790,10 +774,17 @@ export default function WorldOperator(previousWorld: WorldMinimal, characters: C
       operator.applyRule(rule, { createActorIds: false, stageActorForId: { ...actors } });
     }
 
+    const stageUpdates: Record<string, { actors: unknown }> = {
+      [stage.id]: { actors: u.constant(actors) },
+    };
+    for (const [destStageId, destActors] of Object.entries(crossStageActorsForDestStage)) {
+      stageUpdates[destStageId] = { actors: u.constant(destActors) };
+    }
+
     return u(
       {
         globals: u.constant(globals),
-        stages: { [stage.id]: { actors: u.constant(actors) } },
+        stages: stageUpdates,
         evaluatedTickFrames: frameAccumulator.getFrames(),
       },
       previousWorld,
@@ -818,13 +809,12 @@ export default function WorldOperator(previousWorld: WorldMinimal, characters: C
     actors = deepClone(stage.actors);
     frameAccumulator = new FrameAccumulator(stage.actors);
     evaluatedRuleDetails = {};
+    crossStageActorsForDestStage = {};
 
     Object.values(actors).forEach((actor) => ActorOperator(actor).tickAllRules());
     const evaluatedSomeRule = Object.values(evaluatedRuleDetails).some((actorRuleDetails) =>
       Object.values(actorRuleDetails).some((details) => details.passed),
     );
-
-    const crossStageActorsForDestStage = applyDoorTeleports();
 
     const beforeStages: HistorySnapshot["stages"] = {
       [stage.id]: { actors: stage.actors },

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -76,6 +76,11 @@ export type RuleAction = (
       offset?: PositionRelativeToMainActor;
     }
   | {
+      type: "teleport";
+      actorId: string;
+      doorActorId: string;
+    }
+  | {
       type: "transform";
       actorId: string;
       operation: MathOperation;


### PR DESCRIPTION
## Summary
Adds support for a new "teleport" rule action that allows actors to be moved through door actors to different stages or positions. This replaces the previous implicit door teleportation system with an explicit, recordable action.

## Key Changes

- **New `teleport` action type** in `RuleAction` union type with `actorId` and `doorActorId` fields
- **Teleport action execution** in `WorldOperator.applyRule()`:
  - Reads destination coordinates and stage from door actor variables
  - Moves actor to destination on same stage, or transfers to different stage via `crossStageActorsForDestStage`
  - Validates door character type and destination coordinates
- **Removed `applyDoorTeleports()` function** that previously handled implicit position-based door teleportation
- **Recording system integration** in `buildActionsFromStageActions()`:
  - Detects when an actor moves onto a door position
  - Automatically generates both `move` and `teleport` actions in sequence
  - Passes `characters` parameter to identify door actors
- **UI rendering** in `RecordingActions` panel to display teleport actions with source actor and door actor
- **Cross-stage actor tracking** via `crossStageActorsForDestStage` variable initialized at function scope and reset per rule evaluation
- **Stage update aggregation** to apply actor changes across multiple destination stages in a single world update

## Implementation Details

The teleport action is now an explicit, first-class rule action rather than an implicit side effect of position overlap. When recording demonstrates an actor moving onto a door, the system automatically captures both the movement and the teleport action, making the rule's behavior transparent and editable.

Door validation ensures only actors with `kind === "door"` can serve as teleport destinations, and destination coordinates must be finite numbers. Cross-stage teleports properly clone destination stage actors and remove the actor from the source stage.

https://claude.ai/code/session_018ECLBnCkfxcP5Xr8W8K6R9