### PR TITLE
Add stage selection support to condition rows

### DIFF
--- a/frontend/src/editor/components/stage/recording/condition-rows.tsx
+++ b/frontend/src/editor/components/stage/recording/condition-rows.tsx
@@ -17,6 +17,7 @@ import {
 } from "../../../../types";
 import { pickConditionValueFromKeyboard, selectToolId } from "../../../actions/ui-actions";
 import { TOOLS } from "../../../constants/constants";
+import ConnectedStagePicker from "../../inspector/connected-stage-picker";
 import { AppearanceDropdown, TransformDropdown } from "../../inspector/container-pane-variables";
 import { ActorBlock, ActorVariableBlock, AppearanceBlock, TransformBlock } from "./blocks";
 
@@ -35,6 +36,7 @@ type ImpliedDatatype =
   | { type: "position" }
   | { type: "key" }
   | { type: "actor" }
+  | { type: "stage" }
   | null;
 
 /** Status circle for condition evaluation */
@@ -274,6 +276,18 @@ export const FreeformConditionValue = ({
             {value.constant || "Choose…"}
           </Button>
         );
+      }
+      if (impliedDatatype?.type === "stage") {
+        if (onChange) {
+          return (
+            <ConnectedStagePicker
+              value={value.constant}
+              disabled={false}
+              onChange={(e) => onChange?.({ constant: e.target.value })}
+            />
+          );
+        }
+        return <code>{world.stages[value.constant]?.name ?? value.constant}</code>;
       }
 
       if (onChange) {


### PR DESCRIPTION
## Summary
Adds support for stage-type conditions in the recording/condition system, allowing users to create rules that reference specific stages in their world.

## Changes
- Added `"stage"` as a new implied datatype option in condition rows
- Integrated `ConnectedStagePicker` component to handle stage selection in freeform condition values
- When editing: displays a dropdown picker for selecting stages
- When viewing: displays the stage name from the world state, with fallback to the constant value

## Implementation Details
- The stage picker follows the same pattern as the existing actor picker implementation
- Reuses the existing `ConnectedStagePicker` component from the inspector module
- Properly handles both read-only display mode and editable mode based on the `onChange` callback presence

https://claude.ai/code/session_01VQSWTsB2FwQyVRGPSg3cnT