### PR TITLE
Refactor stage scaling to use explicit zoom controls

### DIFF
--- a/frontend/src/editor/components/modal-stages/settings.tsx
+++ b/frontend/src/editor/components/modal-stages/settings.tsx
@@ -190,7 +190,9 @@ export const StageSettings = ({
             defaultValue={height}
             onBlur={(e) => onChange({ height: Number(e.target.value) })}
           />
-          <span style={{ paddingLeft: 20, paddingRight: 10 }}>Tile size:</span>
+          <span style={{ paddingLeft: 20, paddingRight: 10, whiteSpace: "nowrap" }}>
+            Tile size:
+          </span>
           <select
             className="form-control"
             value={tileScale}
@@ -207,8 +209,16 @@ export const StageSettings = ({
             ))}
           </select>
         </div>
-        <div style={{ display: "flex", flexDirection: "row", marginTop: 8 }}>
-          <div className="form-check" style={{ flex: 1 }}>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1fr 1fr",
+            rowGap: 6,
+            columnGap: 16,
+            marginTop: 12,
+          }}
+        >
+          <div className="form-check">
             <label className="form-check-label" htmlFor="zoomToFill">
               <input
                 style={{ marginRight: 5 }}
@@ -223,7 +233,7 @@ export const StageSettings = ({
               Zoom in to fill the screen
             </label>
           </div>
-          <div className="form-check" style={{ flex: 1, marginLeft: 10 }}>
+          <div className="form-check">
             <label className="form-check-label" htmlFor="zoomToFit">
               <input
                 style={{ marginRight: 5 }}
@@ -238,11 +248,7 @@ export const StageSettings = ({
               Zoom out to fit the screen
             </label>
           </div>
-        </div>
-      </fieldset>
-      <fieldset className="form-group">
-        <div style={{ display: "flex", flexDirection: "row" }}>
-          <div className="form-check" style={{ flex: 1 }}>
+          <div className="form-check">
             <label className="form-check-label" htmlFor="wrapX">
               <input
                 style={{ marginRight: 5 }}
@@ -252,22 +258,22 @@ export const StageSettings = ({
                 defaultChecked={wrapX}
                 onBlur={(e) => onChange({ wrapX: e.target.checked })}
               />
-              Wrap Horizontally
+              Wrap horizontally
             </label>
           </div>
-          <div className="form-check" style={{ flex: 1, marginLeft: 10 }}>
+          <div className="form-check">
             <label className="form-check-label" htmlFor="wrapY">
               <input
+                style={{ marginRight: 5 }}
                 className="form-check-input"
                 id="wrapY"
                 type="checkbox"
                 defaultChecked={wrapY}
                 onBlur={(e) => onChange({ wrapY: e.target.checked })}
               />
-              Wrap Vertically
+              Wrap vertically
             </label>
           </div>
-          <div className="form-check" style={{ flex: 1 }}></div>
         </div>
       </fieldset>
       <fieldset className="form-group" style={{ marginTop: 12 }}>

--- a/frontend/src/editor/components/modal-stages/settings.tsx
+++ b/frontend/src/editor/components/modal-stages/settings.tsx
@@ -146,6 +146,11 @@ export const StageSettings = ({
   };
 
   const { width, height, scale, wrapX, wrapY, name, background } = stage;
+  // Legacy `scale: "fit"` maps to the new zoomToFill + zoomToFit checkboxes; the
+  // tile-size dropdown defaults to 1.0 (40px) in that case.
+  const tileScale = scale === "fit" ? 1 : (scale ?? 1);
+  const zoomToFill = scale === "fit" ? true : (stage.zoomToFill ?? true);
+  const zoomToFit = scale === "fit" ? true : (stage.zoomToFit ?? false);
 
   const backgroundAsURL = (/url\((.*)\)/.exec(background) || [])[1];
   const backgroundAsColor = backgroundAsURL ? null : background;
@@ -185,19 +190,54 @@ export const StageSettings = ({
             defaultValue={height}
             onBlur={(e) => onChange({ height: Number(e.target.value) })}
           />
-          <span style={{ paddingLeft: 20, paddingRight: 10 }}>Tiles:</span>
+          <span style={{ paddingLeft: 20, paddingRight: 10 }}>Tile size:</span>
           <select
             className="form-control"
-            value={scale ?? 1}
+            value={tileScale}
             onChange={(e) =>
-              onChange({ scale: e.target.value === "fit" ? "fit" : Number(e.target.value) })
+              onChange({
+                scale: Number(e.target.value),
+                zoomToFill,
+                zoomToFit,
+              })
             }
           >
-            <option value={"fit"}>Fit Screen</option>
             {STAGE_ZOOM_STEPS.map((s) => (
               <option value={s} key={s}>{`${Math.round(STAGE_CELL_SIZE * s)}px`}</option>
             ))}
           </select>
+        </div>
+        <div style={{ display: "flex", flexDirection: "row", marginTop: 8 }}>
+          <div className="form-check" style={{ flex: 1 }}>
+            <label className="form-check-label" htmlFor="zoomToFill">
+              <input
+                style={{ marginRight: 5 }}
+                className="form-check-input"
+                id="zoomToFill"
+                type="checkbox"
+                checked={zoomToFill}
+                onChange={(e) =>
+                  onChange({ scale: tileScale, zoomToFill: e.target.checked, zoomToFit })
+                }
+              />
+              Zoom in to fill the screen
+            </label>
+          </div>
+          <div className="form-check" style={{ flex: 1, marginLeft: 10 }}>
+            <label className="form-check-label" htmlFor="zoomToFit">
+              <input
+                style={{ marginRight: 5 }}
+                className="form-check-input"
+                id="zoomToFit"
+                type="checkbox"
+                checked={zoomToFit}
+                onChange={(e) =>
+                  onChange({ scale: tileScale, zoomToFill, zoomToFit: e.target.checked })
+                }
+              />
+              Zoom out to fit the screen
+            </label>
+          </div>
         </div>
       </fieldset>
       <fieldset className="form-group">

--- a/frontend/src/editor/components/stage/stage.tsx
+++ b/frontend/src/editor/components/stage/stage.tsx
@@ -320,15 +320,21 @@ export const Stage = ({
         zoomToFill: stage.zoomToFill,
         zoomToFit: stage.zoomToFit,
       });
-      const fit = Math.min(
-        _scrollEl.clientWidth / (stage.width * STAGE_CELL_SIZE),
-        _scrollEl.clientHeight / (stage.height * STAGE_CELL_SIZE),
-      );
+      const ratioX = _scrollEl.clientWidth / (stage.width * STAGE_CELL_SIZE);
+      const ratioY = _scrollEl.clientHeight / (stage.height * STAGE_CELL_SIZE);
+      // Aspect-fit: both axes within the viewport, one fills exactly (no scroll).
+      const fit = Math.min(ratioX, ratioY);
+      // Aspect-fill: the shorter axis fills the viewport; the longer one
+      // overflows and scrolls. Used by zoom-to-fill so that a long, thin stage
+      // (e.g. a side-scroller) zooms in to fill the constrained axis.
+      const fill = Math.max(ratioX, ratioY);
       // Start at the configured tile size, then optionally scale up (fill) or
-      // down (fit) based on how the stage compares to the viewport.
+      // down (fit) based on how the stage compares to the viewport. If both
+      // apply (long-thin stage with both checkboxes on), zoom-in wins because
+      // filling the short axis is the more immersive choice.
       let best = tileScale;
-      if (fit > tileScale && zoomToFill) best = fit;
       if (fit < tileScale && zoomToFit) best = fit;
+      if (fill > tileScale && zoomToFill) best = fill;
       _el.style.zoom = `${best}`;
       setScale(best);
 

--- a/frontend/src/editor/components/stage/stage.tsx
+++ b/frontend/src/editor/components/stage/stage.tsx
@@ -320,21 +320,15 @@ export const Stage = ({
         zoomToFill: stage.zoomToFill,
         zoomToFit: stage.zoomToFit,
       });
-      const ratioX = _scrollEl.clientWidth / (stage.width * STAGE_CELL_SIZE);
-      const ratioY = _scrollEl.clientHeight / (stage.height * STAGE_CELL_SIZE);
-      // Aspect-fit: both axes within the viewport, one fills exactly (no scroll).
-      const fit = Math.min(ratioX, ratioY);
-      // Aspect-fill: the shorter axis fills the viewport; the longer one
-      // overflows and scrolls. Used by zoom-to-fill so that a long, thin stage
-      // (e.g. a side-scroller) zooms in to fill the constrained axis.
-      const fill = Math.max(ratioX, ratioY);
+      const fit = Math.min(
+        _scrollEl.clientWidth / (stage.width * STAGE_CELL_SIZE),
+        _scrollEl.clientHeight / (stage.height * STAGE_CELL_SIZE),
+      );
       // Start at the configured tile size, then optionally scale up (fill) or
-      // down (fit) based on how the stage compares to the viewport. If both
-      // apply (long-thin stage with both checkboxes on), zoom-in wins because
-      // filling the short axis is the more immersive choice.
+      // down (fit) based on how the stage compares to the viewport.
       let best = tileScale;
+      if (fit > tileScale && zoomToFill) best = fit;
       if (fit < tileScale && zoomToFit) best = fit;
-      if (fill > tileScale && zoomToFill) best = fill;
       _el.style.zoom = `${best}`;
       setScale(best);
 

--- a/frontend/src/editor/components/stage/stage.tsx
+++ b/frontend/src/editor/components/stage/stage.tsx
@@ -109,6 +109,24 @@ EMPTY_DRAG_IMAGE.src =
 // eslint-disable-next-line react-refresh/only-export-components
 export const STAGE_ZOOM_STEPS = [1, 0.88, 0.75, 0.63, 0.5, 0.42, 0.38];
 
+// Resolves a Stage's scale settings, handling the legacy `scale: "fit"` value
+// by translating it to the equivalent zoom-to-fill + zoom-to-fit configuration.
+// eslint-disable-next-line react-refresh/only-export-components
+export function resolveStageScaleSettings(stage: {
+  scale?: number | "fit";
+  zoomToFill?: boolean;
+  zoomToFit?: boolean;
+}): { tileScale: number; zoomToFill: boolean; zoomToFit: boolean } {
+  if (stage.scale === "fit") {
+    return { tileScale: 1, zoomToFill: true, zoomToFit: true };
+  }
+  return {
+    tileScale: typeof stage.scale === "number" ? stage.scale : 1,
+    zoomToFill: stage.zoomToFill ?? true,
+    zoomToFit: stage.zoomToFit ?? false,
+  };
+}
+
 const SpriteDragPreview = ({
   spriteDrag,
   characters,
@@ -252,14 +270,11 @@ export const Stage = ({
   stage,
   world,
   interactionMode = "full",
-  immersive,
   style,
   doorsPointingHere,
 }: StageProps) => {
   const [{ top, left }, setOffset] = useState<Offset>({ top: 0, left: 0 });
-  const [scale, setScale] = useState(
-    stage.scale && typeof stage.scale === "number" ? stage.scale : 1,
-  );
+  const [scale, setScale] = useState(() => resolveStageScaleSettings(stage).tileScale);
 
   const [selectionRect, setSelectionRect] = useState<SelectionRect | null>(null);
   const [actorSelectionPopover, setActorSelectionPopover] = useState<{
@@ -296,40 +311,39 @@ export const Stage = ({
         setCenteringOffset({ left: 0, top: 0 });
         _scrollEl.style.justifyContent = "";
         _scrollEl.style.alignItems = "";
-      } else if (immersive || stage.scale === "fit") {
-        _el.style.zoom = "1"; // this needs to be here for scaling "up" to work
-        const fit = Math.min(
-          _scrollEl.clientWidth / (stage.width * STAGE_CELL_SIZE),
-          _scrollEl.clientHeight / (stage.height * STAGE_CELL_SIZE),
-        );
-        // In immersive mode, use the stage's intrinsic tile size (stage.scale) as a minimum
-        // zoom so the stage scrolls rather than shrinking below its configured size.
-        // If stage.scale is "fit" or unset, no minimum is applied.
-        const minZoom = immersive && stage.scale !== "fit" ? (stage.scale ?? 1) : 0;
-        const best = immersive
-          ? Math.max(minZoom, fit)
-          : STAGE_ZOOM_STEPS.find((z) => z <= fit) || fit;
-        _el.style.zoom = `${best}`;
-        setScale(best);
-
-        // Disable centering only on axes that overflow so the stage remains centered
-        // on any axis that still fits within the viewport.
-        const stageW = stage.width * STAGE_CELL_SIZE * best;
-        const stageH = stage.height * STAGE_CELL_SIZE * best;
-        const overflowsX = stageW > _scrollEl.clientWidth;
-        const overflowsY = stageH > _scrollEl.clientHeight;
-        _scrollEl.style.justifyContent = overflowsX ? "flex-start" : "";
-        _scrollEl.style.alignItems = overflowsY ? "flex-start" : "";
-        setCenteringOffset({
-          left: overflowsX ? 0 : Math.max(0, (_scrollEl.clientWidth - stageW) / 2),
-          top: overflowsY ? 0 : Math.max(0, (_scrollEl.clientHeight - stageH) / 2),
-        });
-      } else {
-        setScale(stage.scale ?? 1);
-        setCenteringOffset({ left: 0, top: 0 });
-        _scrollEl.style.justifyContent = "";
-        _scrollEl.style.alignItems = "";
+        return;
       }
+
+      _el.style.zoom = "1"; // this needs to be here for scaling "up" to work
+      const { tileScale, zoomToFill, zoomToFit } = resolveStageScaleSettings({
+        scale: stage.scale,
+        zoomToFill: stage.zoomToFill,
+        zoomToFit: stage.zoomToFit,
+      });
+      const fit = Math.min(
+        _scrollEl.clientWidth / (stage.width * STAGE_CELL_SIZE),
+        _scrollEl.clientHeight / (stage.height * STAGE_CELL_SIZE),
+      );
+      // Start at the configured tile size, then optionally scale up (fill) or
+      // down (fit) based on how the stage compares to the viewport.
+      let best = tileScale;
+      if (fit > tileScale && zoomToFill) best = fit;
+      if (fit < tileScale && zoomToFit) best = fit;
+      _el.style.zoom = `${best}`;
+      setScale(best);
+
+      // Disable centering only on axes that overflow so the stage remains centered
+      // on any axis that still fits within the viewport.
+      const stageW = stage.width * STAGE_CELL_SIZE * best;
+      const stageH = stage.height * STAGE_CELL_SIZE * best;
+      const overflowsX = stageW > _scrollEl.clientWidth;
+      const overflowsY = stageH > _scrollEl.clientHeight;
+      _scrollEl.style.justifyContent = overflowsX ? "flex-start" : "";
+      _scrollEl.style.alignItems = overflowsY ? "flex-start" : "";
+      setCenteringOffset({
+        left: overflowsX ? 0 : Math.max(0, (_scrollEl.clientWidth - stageW) / 2),
+        top: overflowsY ? 0 : Math.max(0, (_scrollEl.clientHeight - stageH) / 2),
+      });
     };
 
     // ResizeObserver fires during CSS transitions (e.g. split-stage close animation),
@@ -346,7 +360,14 @@ export const Stage = ({
       window.removeEventListener("resize", autofit);
       document.removeEventListener("fullscreenchange", autofit);
     };
-  }, [stage.height, stage.scale, stage.width, recordingCentered, immersive]);
+  }, [
+    stage.height,
+    stage.scale,
+    stage.zoomToFill,
+    stage.zoomToFit,
+    stage.width,
+    recordingCentered,
+  ]);
 
   const dispatch = useDispatch();
   const characters = useEditorSelector((state) => state.characters);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -208,6 +208,8 @@ export type Stage = {
   wrapX: boolean;
   wrapY: boolean;
   scale?: number | "fit";
+  zoomToFill?: boolean;
+  zoomToFit?: boolean;
   tutorial_name?: string;
   tutorial_step?: number;
   world?: string;


### PR DESCRIPTION
## Summary
Replace the legacy `scale: "fit"` setting with explicit `zoomToFill` and `zoomToFit` boolean flags, providing more granular control over how stages scale to fit the viewport. This change simplifies the scaling logic and removes the special-case `immersive` prop.

## Key Changes
- **New utility function** `resolveStageScaleSettings()` in `stage.tsx` handles migration of legacy `scale: "fit"` to the new zoom control flags
- **Updated Stage type** in `types.ts` to include `zoomToFill` and `zoomToFit` optional boolean properties alongside the existing `scale` property
- **Simplified scaling logic** in the Stage component's resize handler:
  - Removed separate branches for `immersive` mode and `scale: "fit"`
  - Consolidated into unified logic that respects `tileScale` (base tile size) and applies zoom rules based on viewport fit
  - `zoomToFill`: scales up if stage is smaller than viewport
  - `zoomToFit`: scales down if stage is larger than viewport
- **Updated StageSettings UI** to expose the new zoom controls:
  - Renamed "Tiles" dropdown to "Tile size" (now only shows numeric options, not "Fit Screen")
  - Added two checkboxes for "Zoom in to fill the screen" and "Zoom out to fit the screen"
  - Properly maps legacy `scale: "fit"` to `tileScale: 1, zoomToFill: true, zoomToFit: true`
- **Removed `immersive` prop** from Stage component signature and dependency array

## Implementation Details
- The `resolveStageScaleSettings()` function provides backward compatibility by translating the legacy `scale: "fit"` value to the new configuration
- Default behavior preserves existing semantics: `zoomToFill` defaults to `true`, `zoomToFit` defaults to `false`
- The scaling algorithm now clearly separates concerns: tile size (base scale) vs. viewport adaptation (zoom rules)

https://claude.ai/code/session_01Uem46YTFcd8DFzTa7yLnM2