### PR TITLE
Fix state propagation in PixelSelectionTool mouse handlers

### DIFF
--- a/frontend/src/editor/components/modal-paint/tools.ts
+++ b/frontend/src/editor/components/modal-paint/tools.ts
@@ -304,26 +304,27 @@ class PixelSelectionTool extends PixelTool {
       };
     }
 
-    const result = {
-      ...super.mousedown(point, props),
+    const next = { ...props, ...super.mousedown(point, props) };
+    return {
+      ...next,
       imageData: getFlattenedImageData(props),
       selectionImageData: null,
       selectionOffset: { x: 0, y: 0 },
-      interactionPixels: this.selectionPixelsForProps(props),
+      interactionPixels: this.selectionPixelsForProps(next),
     };
-    return result;
   }
 
   mousemove(point: Point, props: PixelToolState): Partial<PixelToolState> {
+    const next = { ...props, ...super.mousemove(point, props) };
     if (props.draggingSelection) {
       return {
-        ...super.mousemove(point, props),
-        selectionOffset: this.selectionOffsetForProps(props),
+        ...next,
+        selectionOffset: this.selectionOffsetForProps(next),
       };
     }
     return {
-      ...super.mousemove(point, props),
-      interactionPixels: this.selectionPixelsForProps(props),
+      ...next,
+      interactionPixels: this.selectionPixelsForProps(next),
     };
   }
 


### PR DESCRIPTION
## Summary
Fixed a bug in the `PixelSelectionTool` class where parent class state changes from `mousedown` and `mousemove` handlers were not being properly propagated to child method calls, causing stale props to be used for computing selection pixels and offsets.

## Key Changes
- **mousedown handler**: Changed to merge parent class state into a `next` object before passing to `selectionPixelsForProps()`, ensuring the method receives updated state rather than the original props
- **mousemove handler**: Applied the same fix for both the `draggingSelection` and default branches, merging parent state into `next` before passing to `selectionOffsetForProps()` and `selectionPixelsForProps()`
- **Code simplification**: Removed unnecessary intermediate `result` variable in `mousedown` and consolidated state merging logic

## Implementation Details
The fix ensures that when parent class handlers (`super.mousedown()` and `super.mousemove()`) return state updates, those updates are immediately available to subsequent method calls within the same handler. This prevents bugs where selection calculations would use stale property values from before the parent handler executed.

https://claude.ai/code/session_01Hax2b8P8zAVQ1sLFPaLhAy