### PR TITLE
Refactor toolbar spacing to use flexbox gap

### DIFF
--- a/frontend/src/editor/components/toolbar.tsx
+++ b/frontend/src/editor/components/toolbar.tsx
@@ -184,7 +184,7 @@ const Toolbar = () => {
     <div className="toolbar">
       <div style={{ flex: 1, textAlign: "left" }}>{renderLeft()}</div>
 
-      <div style={{ display: "flex", alignItems: "center" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
         <div className="button-group">{[TOOLS.POINTER].map(renderTool)}</div>
         <div className="button-group">
           {[TOOLS.CREATE_CHARACTER, TOOLS.PAINT, TOOLS.RECORD].map(renderTool)}
@@ -192,7 +192,7 @@ const Toolbar = () => {
         <div className="button-group">{[TOOLS.STAMP, TOOLS.TRASH].map(renderTool)}</div>
       </div>
 
-      <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "flex-end" }}>
+      <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "flex-end", gap: 12 }}>
         <UndoRedoControls />
         <StageSwitcher />
       </div>

--- a/frontend/src/editor/styles/editor.scss
+++ b/frontend/src/editor/styles/editor.scss
@@ -190,7 +190,6 @@ html {
 
     .button-group {
       display: inline-block;
-      margin-right: 10px;
 
       button {
         margin-right: 0;


### PR DESCRIPTION
## Summary
Replaced manual margin-based spacing in the toolbar with flexbox `gap` property for more consistent and maintainable layout.

## Changes
- Added `gap: 12` to the center toolbar section containing tool button groups
- Added `gap: 12` to the right toolbar section containing undo/redo and stage switcher controls
- Removed `margin-right: 10px` from `.button-group` in editor.scss, as spacing is now handled by flexbox gap

## Details
This refactoring improves the toolbar layout by:
- Using modern flexbox `gap` property instead of relying on margin hacks
- Providing consistent 12px spacing between button groups and controls
- Reducing CSS complexity by removing the need for margin-based spacing rules
- Making the spacing more predictable and easier to adjust in the future

https://claude.ai/code/session_01NFrhKEGN923LhYj4gaVHk8