### PR TITLE
Fix asset paths to use relative imports instead of absolute

### DIFF
--- a/frontend/src/editor/components/inspector/transform-editor.tsx
+++ b/frontend/src/editor/components/inspector/transform-editor.tsx
@@ -69,7 +69,7 @@ export const TransformEditorModal = ({
             border: "2px solid #ccc",
             margin: "auto",
             zoom: 1.2,
-            background: `url('/src/editor/img/board-grid.png') top left / ${STAGE_CELL_SIZE}px`,
+            background: `url('${new URL("../../img/board-grid.png", import.meta.url).href}') top left / ${STAGE_CELL_SIZE}px`,
           }}
         >
           {characterId && appearance && (

--- a/frontend/src/editor/components/stage/stage.tsx
+++ b/frontend/src/editor/components/stage/stage.tsx
@@ -1310,7 +1310,7 @@ export const Stage = ({
   const backgroundValue =
     typeof stage.background === "string"
       ? stage.background.includes("/Layer0_2.png")
-        ? `url(${new URL(`/src/editor/img/backgrounds/Layer0_2.png`, import.meta.url).href})`
+        ? `url(${new URL(`../../img/backgrounds/Layer0_2.png`, import.meta.url).href})`
         : stage.background
       : "";
 
@@ -1319,7 +1319,7 @@ export const Stage = ({
   // For solid color backgrounds the overlay is never applied.
   const applyFade = isImageBackground && stage.backgroundFade !== false;
   const backgroundCSS = [
-    `url('/src/editor/img/board-grid.png') top left / ${STAGE_CELL_SIZE}px`,
+    `url('${new URL("../../img/board-grid.png", import.meta.url).href}') top left / ${STAGE_CELL_SIZE}px`,
     applyFade ? `linear-gradient(rgba(255,255,255,0.25), rgba(255,255,255,0.25))` : null,
     `${backgroundValue}${isImageBackground ? " 50% 50% / cover" : ""}`,
   ]


### PR DESCRIPTION
## Summary
Updates asset path references in the stage and transform editor components to use relative imports via `import.meta.url` instead of absolute paths. This ensures assets are correctly resolved in production builds.

## Changes
- **stage.tsx**: 
  - Changed Layer0_2.png background from absolute path `/src/editor/img/backgrounds/Layer0_2.png` to relative path `../../img/backgrounds/Layer0_2.png`
  - Changed board-grid.png from absolute path `/src/editor/img/board-grid.png` to relative import using `new URL()` with `import.meta.url`

- **transform-editor.tsx**:
  - Changed board-grid.png from absolute path `/src/editor/img/board-grid.png` to relative import using `new URL()` with `import.meta.url`

## Implementation Details
The changes use Vite's `import.meta.url` to resolve asset paths relative to the current module, which is the recommended approach for ensuring assets are correctly bundled and available in production builds. This replaces hardcoded absolute paths that may not work correctly after the frontend is compiled into the `api/frontend/` directory.

https://claude.ai/code/session_0122KictSPBwKV3aX3F7uUaJ