### PR TITLE
Add loading states to recording and paint dialogs

### DIFF
--- a/frontend/src/editor/components/modal-paint/container.tsx
+++ b/frontend/src/editor/components/modal-paint/container.tsx
@@ -130,6 +130,8 @@ const PaintContainer: React.FC = () => {
     reduxDispatch(paintCharacterAppearance(null));
   }, [reduxDispatch]);
 
+  const [isSaving, setIsSaving] = useState(false);
+
   const handleCloseAndSave = useCallback(async () => {
     if (!characterId || !appearanceId || !character) return;
 
@@ -146,6 +148,7 @@ const PaintContainer: React.FC = () => {
     // Generate name if untitled
     let generatedSpriteName = "";
     if (character.name === "Untitled") {
+      setIsSaving(true);
       try {
         const nameResp = await makeRequest<{ name?: string }>("/generate-sprite-name", {
           method: "POST",
@@ -156,6 +159,8 @@ const PaintContainer: React.FC = () => {
         }
       } catch (err) {
         console.error("Failed to auto-generate sprite name:", err);
+      } finally {
+        setIsSaving(false);
       }
     }
 
@@ -465,7 +470,7 @@ const PaintContainer: React.FC = () => {
             <i className="fa fa-magic" style={{ color: "#7b5ea7" }} /> Draw with AI
           </Button>
           <div style={{ flex: 1 }} />
-          <Button key="cancel" onClick={handleClose}>
+          <Button key="cancel" onClick={handleClose} disabled={isSaving}>
             Cancel
           </Button>{" "}
           <Button
@@ -473,7 +478,9 @@ const PaintContainer: React.FC = () => {
             key="save"
             data-tutorial-id="paint-save-and-close"
             onClick={handleCloseAndSave}
+            disabled={isSaving}
           >
+            {isSaving && <i className="fa fa-spinner fa-spin" style={{ marginRight: 6 }} />}
             Done
           </Button>
         </ModalFooter>

--- a/frontend/src/editor/components/stage/stage-recording-controls.tsx
+++ b/frontend/src/editor/components/stage/stage-recording-controls.tsx
@@ -1,5 +1,5 @@
 import { Button } from "reactstrap";
-import React from "react";
+import React, { useState } from "react";
 import { Dispatch } from "redux";
 
 import { makeRequest } from "../../../helpers/api";
@@ -179,6 +179,8 @@ const StageRecordingControls: React.FC<StageRecordingControlsProps> = ({
   recording,
   characters,
 }) => {
+  const [isFinishing, setIsFinishing] = useState(false);
+
   const onCancel = () => {
     dispatch(cancelRecording());
   };
@@ -186,6 +188,7 @@ const StageRecordingControls: React.FC<StageRecordingControlsProps> = ({
   const onNext = async () => {
     let generatedName = "Untitled Rule";
 
+    setIsFinishing(true);
     try {
       const payload = buildNamingPayload(recording, characters);
 
@@ -201,6 +204,8 @@ const StageRecordingControls: React.FC<StageRecordingControlsProps> = ({
       }
     } catch (err) {
       console.error("Failed to auto-generate rule name:", err);
+    } finally {
+      setIsFinishing(false);
     }
 
     dispatch(finishRecording(generatedName));
@@ -214,10 +219,20 @@ const StageRecordingControls: React.FC<StageRecordingControlsProps> = ({
       </div>
       <div style={{ flex: 1 }} />
       <div className="right">
-        <Button onClick={onCancel}>Cancel</Button>{" "}
-        <Button data-tutorial-id="record-next-step" color="success" onClick={onNext}>
+        <Button onClick={onCancel} disabled={isFinishing}>Cancel</Button>{" "}
+        <Button
+          data-tutorial-id="record-next-step"
+          color="success"
+          onClick={onNext}
+          disabled={isFinishing}
+        >
           <span>
-            <i className="fa fa-checkmark" /> Done
+            {isFinishing ? (
+              <i className="fa fa-spinner fa-spin" style={{ marginRight: 6 }} />
+            ) : (
+              <i className="fa fa-checkmark" />
+            )}{" "}
+            Done
           </span>
         </Button>{" "}
       </div>


### PR DESCRIPTION
## Summary
Add visual feedback and disable user interactions during async operations in the stage recording controls and paint modal. This prevents users from triggering multiple submissions while the system is processing rule name generation or sprite name generation.

## Key Changes
- **Stage Recording Controls** (`stage-recording-controls.tsx`):
  - Added `isFinishing` state to track when the "Done" button is processing
  - Disable both "Cancel" and "Done" buttons while `isFinishing` is true
  - Show a spinning loader icon on the "Done" button during processing
  - Set `isFinishing` to false in a finally block to ensure cleanup on success or error

- **Paint Modal** (`modal-paint/container.tsx`):
  - Added `isSaving` state to track when the "Done" button is processing
  - Disable both "Cancel" and "Done" buttons while `isSaving` is true
  - Show a spinning loader icon on the "Done" button during processing
  - Set `isSaving` to false in a finally block to ensure cleanup on success or error

## Implementation Details
Both changes follow the same pattern:
- Use React's `useState` hook to manage loading state
- Wrap async operations with state management (set to true before, false in finally)
- Disable buttons and show visual feedback (spinning icon) during processing
- Ensures users cannot accidentally trigger duplicate submissions while waiting for API responses

https://claude.ai/code/session_01J9Um3osJwD5F6inQwpKwE2