### PR TITLE
Refactor variables panel into tabbed sub-sections

### DIFF
--- a/frontend/src/editor/components/inspector/add-variable-button.tsx
+++ b/frontend/src/editor/components/inspector/add-variable-button.tsx
@@ -1,48 +1,48 @@
-import { ButtonDropdown, DropdownItem, DropdownMenu, DropdownToggle } from "reactstrap";
-import { useState } from "react";
+import { Button } from "reactstrap";
 import { useDispatch } from "react-redux";
-import { Actor, Character } from "../../../types";
+import { Character } from "../../../types";
 import { createCharacterVariable } from "../../actions/characters-actions";
 import { createGlobal, createStageVariable } from "../../actions/world-actions";
 
-const VariablesAddButton = ({ character }: { character: Character; actor: Actor }) => {
-  const [open, setOpen] = useState(false);
+export type VariablesSubTab = "character" | "level" | "world";
+
+const VariablesAddButton = ({
+  character,
+  section,
+}: {
+  character: Character | null;
+  section: VariablesSubTab;
+}) => {
   const dispatch = useDispatch();
 
-  const _onCreateVar = () => {
-    dispatch(createCharacterVariable(character.id));
+  // The plus button adds a variable to whichever section the user is
+  // currently looking at, so its behavior follows the active sub-tab.
+  const _onClick = () => {
+    if (section === "character") {
+      if (!character) return;
+      dispatch(createCharacterVariable(character.id));
+    } else if (section === "level") {
+      dispatch(createStageVariable());
+    } else {
+      dispatch(createGlobal());
+    }
   };
 
-  const _onCreateGlobal = () => {
-    dispatch(createGlobal());
-  };
-
-  const _onCreateStageVar = () => {
-    dispatch(createStageVariable());
-  };
+  const label = {
+    character: "Add Character Variable",
+    level: "Add Level Variable",
+    world: "Add World Variable",
+  }[section];
 
   return (
-    <ButtonDropdown
-      isOpen={open}
-      data-tutorial-id="inspector-add-rule"
-      toggle={() => setOpen(!open)}
+    <Button
+      className="inspector-subnav-add"
+      title={label}
+      disabled={section === "character" && !character}
+      onClick={_onClick}
     >
-      <DropdownToggle caret>
-        <i className="fa fa-plus" />
-      </DropdownToggle>
-      <DropdownMenu right>
-        <DropdownItem disabled={!character} onClick={_onCreateVar}>
-          <span className="badge rule" /> Add Character Variable
-        </DropdownItem>
-        <DropdownItem divider />
-        <DropdownItem onClick={_onCreateStageVar}>
-          <span className="badge rule-flow" /> Add Level Variable
-        </DropdownItem>
-        <DropdownItem onClick={_onCreateGlobal}>
-          <span className="badge rule-flow" /> Add World Variable
-        </DropdownItem>
-      </DropdownMenu>
-    </ButtonDropdown>
+      <i className="fa fa-plus" />
+    </Button>
   );
 };
 

--- a/frontend/src/editor/components/inspector/container-pane-rules.tsx
+++ b/frontend/src/editor/components/inspector/container-pane-rules.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from "react";
 
 import { useDispatch } from "react-redux";
-import { Character, Rule, RuleTreeFlowItemCheck, RuleTreeItem } from "../../../types";
+import { Actor, Character, Rule, RuleTreeFlowItemCheck, RuleTreeItem } from "../../../types";
 import { useEditorSelector } from "../../../hooks/redux";
 import { upsertCharacter } from "../../actions/characters-actions";
 import { editRuleRecording } from "../../actions/recording-actions";
@@ -9,6 +9,7 @@ import { selectRule, selectToolId, selectToolItem } from "../../actions/ui-actio
 import { TOOLS } from "../../constants/constants";
 import { findRule } from "../../utils/stage-helpers";
 import { deepClone, makeId } from "../../utils/utils";
+import AddRuleButton from "./add-rule-button";
 import { RuleList } from "./rule-list";
 
 // eslint-disable-next-line react-refresh/only-export-components
@@ -38,7 +39,13 @@ const cloneRuleWithFreshIds = (item: RuleTreeItem): RuleTreeItem => {
   return copy;
 };
 
-export const ContainerPaneRules = ({ character }: { character: Character | null }) => {
+export const ContainerPaneRules = ({
+  character,
+  actor,
+}: {
+  character: Character | null;
+  actor?: Actor | null;
+}) => {
   const dispatch = useDispatch();
   const { selectedToolId, stampToolItem, selectedRuleId } = useEditorSelector(
     (state) => state.ui,
@@ -326,6 +333,10 @@ export const ContainerPaneRules = ({ character }: { character: Character | null 
         onRuleStamped: _onRuleStamped,
       }}
     >
+      <div className="inspector-subnav">
+        <div className="inspector-subnav-spacer" />
+        <AddRuleButton character={character!} actor={actor!} isRecording={isRecording} />
+      </div>
       <div
         className="scroll-container"
         ref={_scrollContainerEl}

--- a/frontend/src/editor/components/inspector/container-pane-variables.tsx
+++ b/frontend/src/editor/components/inspector/container-pane-variables.tsx
@@ -560,13 +560,23 @@ export const ContainerPaneVariables = ({
     );
   }
 
+  // The Character pill carries the selection context (which actor / how many)
+  // that used to live in an in-panel header above the variable boxes.
+  const characterLabel = character
+    ? actors.length > 1
+      ? `${character.name} (${actors.length} selected)`
+      : actor
+        ? `${character.name} at (${actor.position.x},${actor.position.y})`
+        : `${character.name} (Defaults)`
+    : "Character";
+
   return (
     <>
       <div className="inspector-subnav">
         <Nav pills className="inspector-subnav-pills">
           <NavItem>
             <NavLink active={subTab === "character"} onClick={() => setSubTab("character")}>
-              Character
+              {characterLabel}
             </NavLink>
           </NavItem>
           <NavItem>
@@ -586,30 +596,15 @@ export const ContainerPaneVariables = ({
         <div className="scroll-container-contents">
           {subTab === "character" &&
             (character ? (
-              <div className="variables-section">
-                <h3>
-                  {actors.length > 1
-                    ? `${character.name} (${actors.length} selected)`
-                    : actor
-                      ? `${character.name} at (${actor.position.x},${actor.position.y})`
-                      : `${character.name} (Defaults)`}
-                </h3>
-                {_renderCharacterSection()}
-              </div>
+              <div className="variables-section">{_renderCharacterSection()}</div>
             ) : (
               <div className="empty">Please select a character.</div>
             ))}
           {subTab === "level" && (
-            <div className="variables-section">
-              <h3>Level</h3>
-              {_renderLevelSection()}
-            </div>
+            <div className="variables-section">{_renderLevelSection()}</div>
           )}
           {subTab === "world" && (
-            <div className="variables-section">
-              <h3>World</h3>
-              {_renderWorldSection()}
-            </div>
+            <div className="variables-section">{_renderWorldSection()}</div>
           )}
         </div>
 

--- a/frontend/src/editor/components/inspector/container-pane-variables.tsx
+++ b/frontend/src/editor/components/inspector/container-pane-variables.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 
 
 import { useDispatch } from "react-redux";
-import { Button, ButtonDropdown, DropdownItem, DropdownMenu, DropdownToggle, Modal, ModalBody, ModalFooter, ModalHeader } from "reactstrap";
+import { Button, ButtonDropdown, DropdownItem, DropdownMenu, DropdownToggle, Modal, ModalBody, ModalFooter, ModalHeader, Nav, NavItem, NavLink } from "reactstrap";
 import { DeepPartial } from "redux";
 import { Actor, ActorTransform, Character, Global, RuleTreeItem, StageVariable, WorldMinimal } from "../../../types";
 import { useEditorSelector } from "../../../hooks/redux";
@@ -20,6 +20,7 @@ import { TOOLS } from "../../constants/constants";
 import { getCurrentStageForWorld } from "../../utils/selectors";
 import { findRules, FindRulesResult, ruleUsesVariable } from "../../utils/stage-helpers";
 import Sprite from "../sprites/sprite";
+import AddVariableButton, { VariablesSubTab } from "./add-variable-button";
 import { TransformEditorModal } from "./transform-editor";
 import { TransformImages, TransformLabels } from "./transform-images";
 import { VariableGridItem } from "./variable-grid-item";
@@ -332,6 +333,7 @@ export const ContainerPaneVariables = ({
   const levelTargetWorld = isRecording ? recording.afterWorld : world;
   const levelTargetStage = getCurrentStageForWorld(levelTargetWorld);
   const [pendingDelete, setPendingDelete] = useState<PendingDeleteState>(null);
+  const [subTab, setSubTab] = useState<VariablesSubTab>("character");
 
   // Chararacter and actor variables
 
@@ -559,40 +561,67 @@ export const ContainerPaneVariables = ({
   }
 
   return (
-    <div className={`scroll-container`}>
-      <div className="scroll-container-contents">
-        {character ? (
-          <div className="variables-section">
-            <h3>
-              {actors.length > 1
-                ? `${character.name} (${actors.length} selected)`
-                : actor
-                  ? `${character.name} at (${actor.position.x},${actor.position.y})`
-                  : `${character.name} (Defaults)`}
-            </h3>
-            {_renderCharacterSection()}
-          </div>
-        ) : (
-          <div className="empty">Please select a character.</div>
-        )}
-        <div className="variables-section">
-          <h3>Level</h3>
-          {_renderLevelSection()}
-        </div>
-        <div className="variables-section">
-          <h3>World</h3>
-          {_renderWorldSection()}
-        </div>
+    <>
+      <div className="inspector-subnav">
+        <Nav pills className="inspector-subnav-pills">
+          <NavItem>
+            <NavLink active={subTab === "character"} onClick={() => setSubTab("character")}>
+              Character
+            </NavLink>
+          </NavItem>
+          <NavItem>
+            <NavLink active={subTab === "level"} onClick={() => setSubTab("level")}>
+              Level
+            </NavLink>
+          </NavItem>
+          <NavItem>
+            <NavLink active={subTab === "world"} onClick={() => setSubTab("world")}>
+              World
+            </NavLink>
+          </NavItem>
+        </Nav>
+        <AddVariableButton character={character} section={subTab} />
       </div>
+      <div className={`scroll-container variables-pane`}>
+        <div className="scroll-container-contents">
+          {subTab === "character" &&
+            (character ? (
+              <div className="variables-section">
+                <h3>
+                  {actors.length > 1
+                    ? `${character.name} (${actors.length} selected)`
+                    : actor
+                      ? `${character.name} at (${actor.position.x},${actor.position.y})`
+                      : `${character.name} (Defaults)`}
+                </h3>
+                {_renderCharacterSection()}
+              </div>
+            ) : (
+              <div className="empty">Please select a character.</div>
+            ))}
+          {subTab === "level" && (
+            <div className="variables-section">
+              <h3>Level</h3>
+              {_renderLevelSection()}
+            </div>
+          )}
+          {subTab === "world" && (
+            <div className="variables-section">
+              <h3>World</h3>
+              {_renderWorldSection()}
+            </div>
+          )}
+        </div>
 
-      {pendingDelete && (
-        <VariableInUseModal
-          variableName={pendingDelete.variableName}
-          rulesUsingVariable={pendingDelete.rulesUsingVariable}
-          onConfirm={_onConfirmDelete}
-          onCancel={_onCancelDelete}
-        />
-      )}
-    </div>
+        {pendingDelete && (
+          <VariableInUseModal
+            variableName={pendingDelete.variableName}
+            rulesUsingVariable={pendingDelete.rulesUsingVariable}
+            onConfirm={_onConfirmDelete}
+            onCancel={_onCancelDelete}
+          />
+        )}
+      </div>
+    </>
   );
 };

--- a/frontend/src/editor/components/inspector/container.tsx
+++ b/frontend/src/editor/components/inspector/container.tsx
@@ -2,8 +2,6 @@ import { Nav, NavItem, NavLink } from "reactstrap";
 import classNames from "classnames";
 import { useEffect, useState } from "react";
 
-import AddRuleButton from "./add-rule-button";
-import AddVariableButton from "./add-variable-button";
 import { ContainerPaneRules } from "./container-pane-rules";
 import { ContainerPaneVariables } from "./container-pane-variables";
 
@@ -40,11 +38,6 @@ export const InspectorContainer = () => {
     variables: ContainerPaneVariables,
   }[activeTab];
 
-  const AddButton = {
-    rules: AddRuleButton,
-    variables: AddVariableButton,
-  }[activeTab];
-
   const isReadonly = isRecording && worldId === recording.beforeWorld.id;
 
   return (
@@ -59,7 +52,7 @@ export const InspectorContainer = () => {
       }}
     >
       <div className={`panel inspector-panel-container tool-supported`}>
-        <Nav tabs>
+        <Nav tabs className="inspector-top-tabs">
           <NavItem>
             <NavLink
               className={classNames({ active: activeTab === "rules" })}
@@ -76,8 +69,6 @@ export const InspectorContainer = () => {
               Variables
             </NavLink>
           </NavItem>
-          <div style={{ flex: 1 }} />
-          <AddButton character={focusedCharacter} actor={focusedActor} isRecording={isRecording} />
         </Nav>
         <ContentContainer world={focusedWorld} character={focusedCharacter} actor={focusedActor} actors={focusedActors} readonly={isReadonly} />
       </div>

--- a/frontend/src/editor/styles/editor.scss
+++ b/frontend/src/editor/styles/editor.scss
@@ -867,6 +867,60 @@ html {
   }
 }
 
+// Top-level Rules / Variables tabs split the panel width evenly rather than
+// hugging the left edge.
+.inspector-top-tabs.nav-tabs {
+  flex-wrap: nowrap;
+
+  .nav-item {
+    flex: 1 1 0;
+    text-align: center;
+  }
+  .nav-link {
+    cursor: pointer;
+  }
+}
+
+// Sub-navigation row beneath the top tabs: section pills (Character / Level /
+// World) on the left and the contextual add (+) button on the right.
+.inspector-subnav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 8px 6px;
+  border-bottom: 1px solid #eee;
+
+  .inspector-subnav-pills {
+    flex-wrap: nowrap;
+    gap: 4px;
+
+    .nav-link {
+      cursor: pointer;
+      padding: 3px 12px;
+      font-size: 14px;
+      color: #666;
+    }
+  }
+
+  .inspector-subnav-spacer {
+    flex: 1;
+  }
+}
+
+// In the single-section variables view the pill already names the section, so
+// the fieldset-style border/label on each section just adds noise.
+.variables-pane .variables-section {
+  border-top: none;
+  margin-top: 4px;
+  min-height: 0;
+
+  h3 {
+    top: 0;
+    padding-left: 0;
+  }
+}
+
 .modal-dialog {
   .btn-group > .btn,
   button.btn {

--- a/frontend/src/editor/styles/editor.scss
+++ b/frontend/src/editor/styles/editor.scss
@@ -888,17 +888,25 @@ html {
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  padding: 8px 8px 6px;
+  padding: 8px 0 6px 0px;
   border-bottom: 1px solid #eee;
 
   .inspector-subnav-pills {
-    flex-wrap: wrap;
-    gap: 4px;
+    min-width: 0;
+    gap: 0;
 
+    .nav-item:first-child {
+      min-width: 0;
+      overflow: hidden;
+    }
     .nav-link {
       cursor: pointer;
-      padding: 3px 12px;
+      padding: 4px 10px;
       font-size: 14px;
+      min-width: 0;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      overflow: hidden;
       color: #666;
     }
   }
@@ -912,7 +920,7 @@ html {
 // the fieldset-style border/label on each section just adds noise.
 .variables-pane .variables-section {
   border-top: none;
-  margin-top: 4px;
+  margin-top: 8px;
   min-height: 0;
 }
 

--- a/frontend/src/editor/styles/editor.scss
+++ b/frontend/src/editor/styles/editor.scss
@@ -892,7 +892,7 @@ html {
   border-bottom: 1px solid #eee;
 
   .inspector-subnav-pills {
-    flex-wrap: nowrap;
+    flex-wrap: wrap;
     gap: 4px;
 
     .nav-link {
@@ -914,11 +914,6 @@ html {
   border-top: none;
   margin-top: 4px;
   min-height: 0;
-
-  h3 {
-    top: 0;
-    padding-left: 0;
-  }
 }
 
 .modal-dialog {


### PR DESCRIPTION
## Summary
Restructure the variables inspector panel to use a tabbed navigation system for Character, Level, and World variables, similar to the Rules panel structure. This improves organization and reduces visual clutter by showing only one section at a time.

## Key Changes
- **Container Pane Variables**: Converted from a single-view layout to a tabbed interface with sub-navigation pills for Character/Level/World sections
  - Added `subTab` state to track active section
  - Moved section headers into navigation pills with dynamic labeling for character context (name, position, or "Defaults")
  - Conditionally render only the active section's content
  - Extracted character label logic for reuse in the pill

- **Add Variable Button**: Simplified from a dropdown menu to a single contextual button
  - Exported `VariablesSubTab` type for type safety
  - Button behavior now follows the active sub-tab (adds variable to whichever section user is viewing)
  - Disabled when on Character tab with no character selected
  - Removed actor parameter (no longer needed)

- **Container Pane Rules**: Added matching sub-navigation structure
  - Integrated `AddRuleButton` into a new `inspector-subnav` row below the top tabs
  - Updated component signature to accept optional `actor` parameter

- **Inspector Container**: Removed top-level add buttons
  - Buttons now live in their respective pane's sub-navigation
  - Simplified tab navigation to focus on tab switching only
  - Added `inspector-top-tabs` class for consistent styling

- **Styles**: Added new CSS for sub-navigation layout
  - `.inspector-top-tabs`: Evenly distributed tab widths
  - `.inspector-subnav`: Flex layout with pills on left, add button on right
  - `.variables-pane`: Removed fieldset-style borders from sections since pills now provide context

## Implementation Details
- Character label intelligently displays selection context: shows actor count when multiple selected, position when single actor selected, or "(Defaults)" for character defaults
- Sub-navigation pills use text overflow handling to gracefully truncate long character names
- Add button is disabled contextually (character section requires character selection)
- Maintains existing Redux dispatch patterns for variable creation

https://claude.ai/code/session_01C3K73BDxMJp1k8N4AwvM4D