### PR TITLE
Distribute actor changes evenly across shared timeline

### DIFF
--- a/frontend/src/editor/utils/frame-accumulator.test.ts
+++ b/frontend/src/editor/utils/frame-accumulator.test.ts
@@ -132,6 +132,63 @@ describe("FrameAccumulator", () => {
       expect(frames[2].actors["actor2"].position.x).to.equal(6);
     });
 
+    it("should spread changes evenly across a shared LCM timeline", () => {
+      const actors = {
+        actor1: makeActor("actor1", 0, 0),
+        actor2: makeActor("actor2", 5, 5),
+      };
+      const accumulator = new FrameAccumulator(actors);
+
+      // actor1 has 3 changes, actor2 has 2 changes. To deliver each actor's
+      // changes at multiples of its own transition duration, the timeline must
+      // be lcm(3, 2) = 6 frames long. actor1 lands on slots 0/2/4 and actor2 on
+      // slots 0/3 (so actor2's second move starts exactly halfway, when its
+      // first 500ms-equivalent transition would complete).
+      accumulator.push({ ...makeActor("actor1", 1, 0), actionIdx: 0 });
+      accumulator.push({ ...makeActor("actor1", 2, 0), actionIdx: 1 });
+      accumulator.push({ ...makeActor("actor1", 3, 0), actionIdx: 2 });
+      accumulator.push({ ...makeActor("actor2", 6, 5), actionIdx: 0 });
+      accumulator.push({ ...makeActor("actor2", 7, 5), actionIdx: 1 });
+
+      const frames = accumulator.getFrames();
+      expect(frames).to.have.length(6);
+
+      // actor1 advances on slots 0, 2, 4; holds its value on the slots between.
+      const actor1Xs = frames.map((f) => f.actors["actor1"].position.x);
+      expect(actor1Xs).to.deep.equal([1, 1, 2, 2, 3, 3]);
+
+      // actor2 advances on slots 0 and 3, holding otherwise.
+      const actor2Xs = frames.map((f) => f.actors["actor2"].position.x);
+      expect(actor2Xs).to.deep.equal([6, 6, 6, 7, 7, 7]);
+
+      // frameCount stays per-actor so the CSS transition duration matches each
+      // actor's own change count, not the shared timeline length.
+      expect(frames[0].actors["actor1"].frameCount).to.equal(3);
+      expect(frames[0].actors["actor2"].frameCount).to.equal(2);
+    });
+
+    it("should cap the shared timeline length", () => {
+      const actors = {
+        actor1: makeActor("actor1", 0, 0),
+        actor2: makeActor("actor2", 5, 5),
+      };
+      const accumulator = new FrameAccumulator(actors);
+
+      // lcm(97, 89) = 8633, far above the cap. We fall back to rounded slots.
+      for (let i = 0; i < 97; i++) {
+        accumulator.push({ ...makeActor("actor1", i + 1, 0), actionIdx: i });
+      }
+      for (let i = 0; i < 89; i++) {
+        accumulator.push({ ...makeActor("actor2", i + 6, 5), actionIdx: i });
+      }
+
+      const frames = accumulator.getFrames();
+      expect(frames).to.have.length(100);
+      // frameCount still reflects each actor's true change count.
+      expect(frames[0].actors["actor1"].frameCount).to.equal(97);
+      expect(frames[0].actors["actor2"].frameCount).to.equal(89);
+    });
+
     it("should handle deleted actors", () => {
       const actors = { actor1: makeActor("actor1", 0, 0) };
       const accumulator = new FrameAccumulator(actors);

--- a/frontend/src/editor/utils/frame-accumulator.ts
+++ b/frontend/src/editor/utils/frame-accumulator.ts
@@ -8,6 +8,22 @@ export type FrameActor = Actor & {
 };
 export type Frame = { actors: { [actorId: string]: FrameActor }; id: number };
 
+// Upper bound on the number of frames in a tick's shared timeline. The exact
+// timeline length is the least-common-multiple of every actor's frame count so
+// that each actor's changes land on integer slots, but coprime counts can make
+// the LCM explode (e.g. 7 and 11 => 77). Past this cap we round slot positions
+// instead; the resulting sub-frame jitter is imperceptible.
+const MAX_TIMELINE_FRAMES = 100;
+
+const gcd = (a: number, b: number): number => {
+  while (b) {
+    [a, b] = [b, a % b];
+  }
+  return a;
+};
+
+const lcm = (a: number, b: number): number => (a / gcd(a, b)) * b;
+
 export class FrameAccumulator {
   changes: { [actorId: string]: FrameActor[] } = {};
   initial: Frame;
@@ -20,45 +36,60 @@ export class FrameAccumulator {
     this.changes[actor.id].push(deepClone(actor));
   }
   getFrames() {
-    // Perform the first action for each actor in the first frame, then the second action
-    // for each actor, etc. until there are no more actions to perform.
-    const frames: Frame[] = [];
-    const remaining = { ...this.changes };
+    // Distribute every actor's changes across a single shared timeline so that
+    // each actor's N changes are spread evenly over the whole tick (at fractions
+    // 0, 1/N, 2/N, ... of the duration) rather than bunched into the first N
+    // frames. The playback loop advances all actors on one clock at
+    // `speed / frames.length`, while each actor's CSS transition lasts
+    // `speed / frameCount` (its own change count). For an actor's transitions to
+    // line up with when its changes are actually delivered, change `j` of an
+    // actor with `k` changes must land on slot `j * frames.length / k`. Making
+    // the timeline length the LCM of all change counts keeps those slots integral.
     const frameCountsByActor = Object.fromEntries(
       Object.entries(this.changes).map(([id, a]) => [id, a.length]),
     );
+    const counts = Object.values(frameCountsByActor);
 
-    let current: Frame = deepClone(this.initial);
-    let frameIndex = 1;
-
-    while (true) {
-      const changeActorIds = Object.keys(remaining);
-      if (changeActorIds.length === 0) {
-        break;
-      }
-      for (const actorId of changeActorIds) {
-        const actorVersion = remaining[actorId].shift()!;
-        actorVersion.frameCount = frameCountsByActor[actorId];
-        if (actorVersion.deleted) {
-          delete current.actors[actorId];
-        } else {
-          current.actors[actorId] = actorVersion;
-        }
-        if (remaining[actorId].length === 0) {
-          delete remaining[actorId];
-        }
-      }
-      frames.push(current);
-      current = deepClone(current);
-      // Use integer increment to avoid floating point precision issues
-      current.id = this.initial.id + frameIndex;
-      frameIndex++;
+    // No rules fired: return just the initial frame so the tick clock still
+    // receives a new unique tickKey on every tick.
+    if (counts.length === 0) {
+      return [this.initial];
     }
 
-    // Always return at least the initial frame so that the tick clock
-    // receives a new unique tickKey on every tick, even when no rules fire.
-    if (frames.length === 0) {
-      frames.push(this.initial);
+    const total = Math.min(
+      counts.reduce((acc, count) => lcm(acc, count), 1),
+      MAX_TIMELINE_FRAMES,
+    );
+
+    // Bucket each change onto its proportional slot in the shared timeline.
+    const changesBySlot: { actorId: string; version: FrameActor }[][] = Array.from(
+      { length: total },
+      () => [],
+    );
+    for (const [actorId, versions] of Object.entries(this.changes)) {
+      const count = versions.length;
+      versions.forEach((version, j) => {
+        const slot = Math.min(Math.round((j * total) / count), total - 1);
+        const placed = deepClone(version);
+        placed.frameCount = count;
+        changesBySlot[slot].push({ actorId, version: placed });
+      });
+    }
+
+    const frames: Frame[] = [];
+    let current: Frame = deepClone(this.initial);
+    for (let slot = 0; slot < total; slot++) {
+      for (const { actorId, version } of changesBySlot[slot]) {
+        if (version.deleted) {
+          delete current.actors[actorId];
+        } else {
+          current.actors[actorId] = version;
+        }
+      }
+      // Use integer increment to avoid floating point precision issues
+      current.id = this.initial.id + slot;
+      frames.push(current);
+      current = deepClone(current);
     }
 
     return frames;


### PR DESCRIPTION
## Summary
Refactors the frame accumulation logic to distribute each actor's changes evenly across a shared timeline, rather than bunching them into the first N frames. This ensures that when actors have different numbers of changes, their CSS transitions align properly with when changes are actually delivered.

## Key Changes
- **Added LCM-based timeline calculation**: Computes the least-common-multiple (LCM) of all actors' change counts to determine the shared timeline length, ensuring each actor's changes land on integer frame slots proportional to their duration
- **Implemented timeline length cap**: Added `MAX_TIMELINE_FRAMES = 100` constant to prevent LCM explosion with coprime frame counts (e.g., 7 and 11 → 77). When exceeded, slot positions are rounded with imperceptible sub-frame jitter
- **Added helper functions**: Implemented `gcd()` and `lcm()` utility functions for timeline calculations
- **Refactored frame distribution**: Changed from sequential per-actor processing to slot-based distribution where each actor's j-th change lands on slot `round(j * total / count)`
- **Preserved per-actor frameCount**: Each actor's `frameCount` still reflects its own change count (not the shared timeline length) so CSS transition durations remain correct

## Implementation Details
- The shared timeline ensures actors with different change counts have their transitions properly synchronized. For example, an actor with 3 changes and another with 2 changes now use a 6-frame timeline where changes land at proportional positions (0, 2, 4 and 0, 3 respectively)
- Frame IDs are now calculated as `initial.id + slot` for clarity and to avoid floating-point precision issues
- Added comprehensive test coverage for LCM timeline distribution and timeline length capping

https://claude.ai/code/session_01DxKLWevEfmYNfwyQxS8G37