### PR TITLE
Fix number input spinner alignment in editor

### DIFF
--- a/frontend/src/editor/styles/editor.scss
+++ b/frontend/src/editor/styles/editor.scss
@@ -1328,6 +1328,21 @@ html {
     }
     input.value {
       cursor: text;
+
+      // type="number" inputs render up/down spinner arrows that reserve
+      // horizontal space on the right edge in Chrome/WebKit. That narrows the
+      // content box on the right, so the centered value renders off-center
+      // (shifted left). Hide the spinners so numeric values sit truly centered.
+      &[type="number"] {
+        -moz-appearance: textfield;
+        appearance: textfield;
+
+        &::-webkit-outer-spin-button,
+        &::-webkit-inner-spin-button {
+          -webkit-appearance: none;
+          margin: 0;
+        }
+      }
     }
 
     label.value.variable-boolean {


### PR DESCRIPTION
## Summary
Fixed visual misalignment of centered numeric values in number input fields by hiding the browser-rendered spinner arrows that reserve horizontal space.

## Changes
- Added CSS rules to hide number input spinners across all browsers:
  - Firefox: Use `appearance: textfield` to disable spinner rendering
  - Chrome/WebKit: Target `::-webkit-outer-spin-button` and `::-webkit-inner-spin-button` pseudo-elements with `appearance: none`
  - Reset margin on spinner elements to ensure consistent spacing

## Details
Number inputs in Chrome and WebKit browsers render up/down spinner arrows on the right edge that reserve horizontal space. This narrows the content box and causes centered numeric values to render off-center (shifted left). The fix applies standard CSS techniques to hide these spinners while maintaining the text input functionality, ensuring numeric values display truly centered in the editor.

https://claude.ai/code/session_01AZAPM6uZF7FhSd79mqpvJF