### PR TITLE
Add comment annotations and disable-rule tool to rules sidebar

### DIFF
--- a/frontend/src/editor/components/inspector/comment-editor.tsx
+++ b/frontend/src/editor/components/inspector/comment-editor.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * A small auto-growing text editor used for both free-standing comments and
+ * comment annotations on rules. Edits are committed on blur (matching the
+ * rest of the rule editor). A comment that's left empty is removed.
+ */
+export const CommentTextEditor = ({
+  value,
+  placeholder,
+  onCommit,
+  onRemove,
+}: {
+  value: string;
+  placeholder?: string;
+  onCommit: (text: string) => void;
+  onRemove?: () => void;
+}) => {
+  const ref = useRef<HTMLTextAreaElement>(null);
+  const [text, setText] = useState(value);
+
+  useEffect(() => setText(value), [value]);
+
+  // New comments mount empty — focus so the user can start typing immediately.
+  useEffect(() => {
+    if (value === "") {
+      ref.current?.focus();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const resize = () => {
+    const el = ref.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${el.scrollHeight}px`;
+  };
+  useEffect(resize, [text]);
+
+  const commit = () => {
+    if (text.trim() === "") {
+      onRemove?.();
+    } else if (text !== value) {
+      onCommit(text);
+    }
+  };
+
+  return (
+    <textarea
+      ref={ref}
+      className="comment-text"
+      rows={1}
+      value={text}
+      placeholder={placeholder ?? "Write a note…"}
+      onChange={(e) => setText(e.target.value)}
+      // Keep clicks/drags from reaching the rule-list tool handlers while editing.
+      onClick={(e) => e.stopPropagation()}
+      onMouseDown={(e) => e.stopPropagation()}
+      onDragStart={(e) => e.stopPropagation()}
+      onBlur={commit}
+      onKeyDown={(e) => {
+        if (e.key === "Escape") {
+          e.currentTarget.blur();
+        }
+      }}
+    />
+  );
+};

--- a/frontend/src/editor/components/inspector/comment-tool-button.tsx
+++ b/frontend/src/editor/components/inspector/comment-tool-button.tsx
@@ -1,0 +1,34 @@
+import { Button } from "reactstrap";
+import classNames from "classnames";
+import { useDispatch } from "react-redux";
+
+import { useEditorSelector } from "../../../hooks/redux";
+import { selectToolId } from "../../actions/ui-actions";
+import { TOOLS } from "../../constants/constants";
+
+// A tool local to the rules sidebar. While active, clicking a rule attaches a
+// comment annotation to it, and clicking the space between rules drops a
+// free-standing comment. Clicking the button again (or picking another tool)
+// exits the mode.
+const CommentToolButton = ({ disabled }: { disabled: boolean }) => {
+  const dispatch = useDispatch();
+  const selectedToolId = useEditorSelector((state) => state.ui.selectedToolId);
+  const active = selectedToolId === TOOLS.COMMENT;
+
+  const _onToggle = () => {
+    dispatch(selectToolId(active ? TOOLS.POINTER : TOOLS.COMMENT));
+  };
+
+  return (
+    <Button
+      className={classNames("inspector-subnav-tool", { selected: active })}
+      disabled={disabled}
+      title="Add a comment — click a rule to annotate it, or click between rules to drop a note"
+      onClick={_onToggle}
+    >
+      <i className="fa fa-comment-o" />
+    </Button>
+  );
+};
+
+export default CommentToolButton;

--- a/frontend/src/editor/components/inspector/comment-tool-button.tsx
+++ b/frontend/src/editor/components/inspector/comment-tool-button.tsx
@@ -6,10 +6,7 @@ import { useEditorSelector } from "../../../hooks/redux";
 import { selectToolId } from "../../actions/ui-actions";
 import { TOOLS } from "../../constants/constants";
 
-// A tool local to the rules sidebar. While active, clicking a rule attaches a
-// comment annotation to it, and clicking the space between rules drops a
-// free-standing comment. Clicking the button again (or picking another tool)
-// exits the mode.
+// Toggles the rules-sidebar-local "comment" tool on and off.
 const CommentToolButton = ({ disabled }: { disabled: boolean }) => {
   const dispatch = useDispatch();
   const selectedToolId = useEditorSelector((state) => state.ui.selectedToolId);

--- a/frontend/src/editor/components/inspector/comment-tool-button.tsx
+++ b/frontend/src/editor/components/inspector/comment-tool-button.tsx
@@ -23,7 +23,7 @@ const CommentToolButton = ({ disabled }: { disabled: boolean }) => {
     <Button
       className={classNames("inspector-subnav-tool", { selected: active })}
       disabled={disabled}
-      title="Add a comment — click a rule to annotate it, or click between rules to drop a note"
+      title="Add a comment — click a rule to annotate it, or click between rules to drop a note (hold Shift to add several)"
       onClick={_onToggle}
     >
       <i className="fa fa-comment-o" />

--- a/frontend/src/editor/components/inspector/container-pane-rules.tsx
+++ b/frontend/src/editor/components/inspector/container-pane-rules.tsx
@@ -1,7 +1,14 @@
 import React, { useEffect, useRef } from "react";
 
 import { useDispatch } from "react-redux";
-import { Actor, Character, Rule, RuleTreeFlowItemCheck, RuleTreeItem } from "../../../types";
+import {
+  Actor,
+  Character,
+  Rule,
+  RuleTreeComment,
+  RuleTreeFlowItemCheck,
+  RuleTreeItem,
+} from "../../../types";
 import { useEditorSelector } from "../../../hooks/redux";
 import { upsertCharacter } from "../../actions/characters-actions";
 import { editRuleRecording } from "../../actions/recording-actions";
@@ -10,6 +17,7 @@ import { TOOLS } from "../../constants/constants";
 import { findRule } from "../../utils/stage-helpers";
 import { deepClone, makeId } from "../../utils/utils";
 import AddRuleButton from "./add-rule-button";
+import CommentToolButton from "./comment-tool-button";
 import DisableRuleToolButton from "./disable-rule-tool-button";
 import { RuleList } from "./rule-list";
 
@@ -20,6 +28,8 @@ export const RuleActionsContext = React.createContext<{
   onRuleReRecord: (rule: Rule | RuleTreeFlowItemCheck) => void;
   onRuleChanged: (ruleId: string, changes: Partial<RuleTreeItem>) => void;
   onRuleDeleted: (ruleId: string, event: React.MouseEvent<unknown>) => void;
+  onCommentInserted: (parentId: string | null, index: number) => void;
+  onCommentRemoved: (id: string) => void;
 }>(new Error() as never);
 
 // In-app clipboard for rule copy/paste, shared across mounts of the rules pane.
@@ -273,6 +283,31 @@ export const ContainerPaneRules = ({
     dispatch(upsertCharacter(character.id, { rules }));
   };
 
+  const _onCommentInserted = (parentId: string | null, index: number) => {
+    const rules = deepClone(character.rules);
+    const root = { rules };
+    const [parentRule] = parentId ? findRule(root, parentId) : [root];
+    if (!parentRule || !("rules" in parentRule)) {
+      return;
+    }
+    const comment: RuleTreeComment = { type: "comment", id: makeId("comment"), text: "" };
+    parentRule.rules.splice(index, 0, comment);
+    dispatch(upsertCharacter(character.id, root));
+  };
+
+  const _onCommentRemoved = (id: string) => {
+    const rules = deepClone(character.rules);
+    const [, parentRule, parentIdx] = findRule({ rules }, id);
+    if (!parentRule.rules[parentIdx]) {
+      return;
+    }
+    parentRule.rules.splice(parentIdx, 1);
+    dispatch(upsertCharacter(character.id, { rules }));
+    if (selectedRuleId === id) {
+      dispatch(selectRule(null));
+    }
+  };
+
   const _onRuleStamped = (
     sourceRuleId: string,
     newParentId: string | null,
@@ -332,10 +367,13 @@ export const ContainerPaneRules = ({
         onRuleMoved: _onRuleMoved,
         onRuleDeleted: _onRuleDeleted,
         onRuleStamped: _onRuleStamped,
+        onCommentInserted: _onCommentInserted,
+        onCommentRemoved: _onCommentRemoved,
       }}
     >
       <div className="inspector-subnav">
         <div className="inspector-subnav-spacer" />
+        <CommentToolButton disabled={!character || isRecording} />
         <DisableRuleToolButton disabled={!character || isRecording} />
         <AddRuleButton character={character!} actor={actor!} isRecording={isRecording} />
       </div>

--- a/frontend/src/editor/components/inspector/container-pane-rules.tsx
+++ b/frontend/src/editor/components/inspector/container-pane-rules.tsx
@@ -10,6 +10,7 @@ import { TOOLS } from "../../constants/constants";
 import { findRule } from "../../utils/stage-helpers";
 import { deepClone, makeId } from "../../utils/utils";
 import AddRuleButton from "./add-rule-button";
+import DisableRuleToolButton from "./disable-rule-tool-button";
 import { RuleList } from "./rule-list";
 
 // eslint-disable-next-line react-refresh/only-export-components
@@ -335,6 +336,7 @@ export const ContainerPaneRules = ({
     >
       <div className="inspector-subnav">
         <div className="inspector-subnav-spacer" />
+        <DisableRuleToolButton disabled={!character || isRecording} />
         <AddRuleButton character={character!} actor={actor!} isRecording={isRecording} />
       </div>
       <div

--- a/frontend/src/editor/components/inspector/content-comment.tsx
+++ b/frontend/src/editor/components/inspector/content-comment.tsx
@@ -1,0 +1,37 @@
+import { useContext } from "react";
+
+import { RuleTreeComment } from "../../../types";
+import { CommentTextEditor } from "./comment-editor";
+import { RuleActionsContext } from "./container-pane-rules";
+
+/** A free-standing comment that lives as its own element in the rule list. */
+export const ContentComment = ({ comment }: { comment: RuleTreeComment }) => {
+  const { onRuleChanged, onCommentRemoved } = useContext(RuleActionsContext);
+
+  return (
+    <div className="comment-body">
+      <i className="fa fa-comment-o comment-icon" aria-hidden="true" />
+      <CommentTextEditor
+        value={comment.text}
+        onCommit={(text) => onRuleChanged(comment.id, { text })}
+        onRemove={() => onCommentRemoved(comment.id)}
+      />
+    </div>
+  );
+};
+
+/** A comment annotation that rides along on a rule/container. */
+export const RuleCommentAnnotation = ({ ruleId, text }: { ruleId: string; text: string }) => {
+  const { onRuleChanged } = useContext(RuleActionsContext);
+
+  return (
+    <div className="rule-comment-annotation">
+      <i className="fa fa-comment-o comment-icon" aria-hidden="true" />
+      <CommentTextEditor
+        value={text}
+        onCommit={(t) => onRuleChanged(ruleId, { comment: t })}
+        onRemove={() => onRuleChanged(ruleId, { comment: undefined })}
+      />
+    </div>
+  );
+};

--- a/frontend/src/editor/components/inspector/disable-rule-tool-button.tsx
+++ b/frontend/src/editor/components/inspector/disable-rule-tool-button.tsx
@@ -1,0 +1,33 @@
+import { Button } from "reactstrap";
+import classNames from "classnames";
+import { useDispatch } from "react-redux";
+
+import { useEditorSelector } from "../../../hooks/redux";
+import { selectToolId } from "../../actions/ui-actions";
+import { TOOLS } from "../../constants/constants";
+
+// A tool local to the rules sidebar. While active, clicking a rule toggles
+// whether it's enabled — letting you quickly mute/unmute rules without opening
+// each one. Clicking the button again (or picking another tool) exits the mode.
+const DisableRuleToolButton = ({ disabled }: { disabled: boolean }) => {
+  const dispatch = useDispatch();
+  const selectedToolId = useEditorSelector((state) => state.ui.selectedToolId);
+  const active = selectedToolId === TOOLS.DISABLE_RULE;
+
+  const _onToggle = () => {
+    dispatch(selectToolId(active ? TOOLS.POINTER : TOOLS.DISABLE_RULE));
+  };
+
+  return (
+    <Button
+      className={classNames("inspector-subnav-tool", { selected: active })}
+      disabled={disabled}
+      title="Toggle rules on or off by clicking them"
+      onClick={_onToggle}
+    >
+      <i className="fa fa-ban" />
+    </Button>
+  );
+};
+
+export default DisableRuleToolButton;

--- a/frontend/src/editor/components/inspector/disable-rule-tool-button.tsx
+++ b/frontend/src/editor/components/inspector/disable-rule-tool-button.tsx
@@ -22,7 +22,7 @@ const DisableRuleToolButton = ({ disabled }: { disabled: boolean }) => {
     <Button
       className={classNames("inspector-subnav-tool", { selected: active })}
       disabled={disabled}
-      title="Toggle rules on or off by clicking them"
+      title="Toggle rules on or off by clicking them (hold Shift to toggle several)"
       onClick={_onToggle}
     >
       <i className="fa fa-ban" />

--- a/frontend/src/editor/components/inspector/disable-rule-tool-button.tsx
+++ b/frontend/src/editor/components/inspector/disable-rule-tool-button.tsx
@@ -6,9 +6,7 @@ import { useEditorSelector } from "../../../hooks/redux";
 import { selectToolId } from "../../actions/ui-actions";
 import { TOOLS } from "../../constants/constants";
 
-// A tool local to the rules sidebar. While active, clicking a rule toggles
-// whether it's enabled — letting you quickly mute/unmute rules without opening
-// each one. Clicking the button again (or picking another tool) exits the mode.
+// Toggles the rules-sidebar-local "disable rule" tool on and off.
 const DisableRuleToolButton = ({ disabled }: { disabled: boolean }) => {
   const dispatch = useDispatch();
   const selectedToolId = useEditorSelector((state) => state.ui.selectedToolId);

--- a/frontend/src/editor/components/inspector/rule-list.tsx
+++ b/frontend/src/editor/components/inspector/rule-list.tsx
@@ -32,7 +32,7 @@ export const RuleList = ({
   character: Character;
   collapsed: boolean;
 }) => {
-  const { onRuleMoved, onRuleReRecord, onRuleDeleted, onRuleStamped } =
+  const { onRuleMoved, onRuleReRecord, onRuleDeleted, onRuleStamped, onRuleChanged } =
     useContext(RuleActionsContext);
   const selectedToolId = useEditorSelector((state) => state.ui.selectedToolId);
   const stampToolItem = useEditorSelector((s) => s.ui.stampToolItem);
@@ -103,6 +103,13 @@ export const RuleList = ({
   };
 
   const _onRuleClicked = (event: React.MouseEvent<unknown>, rule: RuleTreeItem) => {
+    if (selectedToolId === TOOLS.DISABLE_RULE) {
+      // Clicking a rule (or container) flips whether it's enabled. Stay in the
+      // tool so several rules can be toggled in a row.
+      event.stopPropagation();
+      onRuleChanged(rule.id, { enabled: rule.enabled === false });
+      return;
+    }
     if (selectedToolId === TOOLS.TRASH) {
       event.stopPropagation();
       onRuleDeleted(rule.id, event);

--- a/frontend/src/editor/components/inspector/rule-list.tsx
+++ b/frontend/src/editor/components/inspector/rule-list.tsx
@@ -112,22 +112,17 @@ export const RuleList = ({
   const _onRuleClicked = (event: React.MouseEvent<unknown>, rule: RuleTreeItem) => {
     if (selectedToolId === TOOLS.COMMENT) {
       event.stopPropagation();
-      // Clicking a rule attaches an (empty, focused) comment annotation. If it
-      // already has one — or it's itself a free-standing comment — do nothing.
       if (rule.type !== "comment" && rule.comment === undefined) {
         onRuleChanged(rule.id, { comment: "" });
       }
-      // One-shot: revert to the pointer unless Shift is held to keep commenting.
       if (!event.shiftKey) {
         dispatch(selectToolId(TOOLS.POINTER));
       }
       return;
     }
     if (selectedToolId === TOOLS.DISABLE_RULE) {
-      // Clicking a rule (or container) flips whether it's enabled.
       event.stopPropagation();
       onRuleChanged(rule.id, { enabled: rule.enabled === false });
-      // One-shot: revert to the pointer unless Shift is held to keep toggling.
       if (!event.shiftKey) {
         dispatch(selectToolId(TOOLS.POINTER));
       }
@@ -219,14 +214,13 @@ export const RuleList = ({
 
   const _onListClick = (event: React.MouseEvent<unknown>) => {
     if (selectedToolId === TOOLS.COMMENT) {
-      // Clicks land here only when they miss a rule (clicks on a rule are
-      // stopped in _onRuleClicked). Drop a free-standing comment at that gap.
+      // Only fires for clicks that miss a rule, so reuse the drag drop-index
+      // math to find which gap was clicked and insert a free-standing comment.
       event.stopPropagation();
       const dropIndex = _dropIndexForEvent(event);
       const insertAt =
         dropIndex === undefined || dropIndex < 0 ? rules.length : Math.min(dropIndex, rules.length);
       onCommentInserted(parentId, insertAt);
-      // One-shot: revert to the pointer unless Shift is held to keep commenting.
       if (!event.shiftKey) {
         dispatch(selectToolId(TOOLS.POINTER));
       }

--- a/frontend/src/editor/components/inspector/rule-list.tsx
+++ b/frontend/src/editor/components/inspector/rule-list.tsx
@@ -117,13 +117,20 @@ export const RuleList = ({
       if (rule.type !== "comment" && rule.comment === undefined) {
         onRuleChanged(rule.id, { comment: "" });
       }
+      // One-shot: revert to the pointer unless Shift is held to keep commenting.
+      if (!event.shiftKey) {
+        dispatch(selectToolId(TOOLS.POINTER));
+      }
       return;
     }
     if (selectedToolId === TOOLS.DISABLE_RULE) {
-      // Clicking a rule (or container) flips whether it's enabled. Stay in the
-      // tool so several rules can be toggled in a row.
+      // Clicking a rule (or container) flips whether it's enabled.
       event.stopPropagation();
       onRuleChanged(rule.id, { enabled: rule.enabled === false });
+      // One-shot: revert to the pointer unless Shift is held to keep toggling.
+      if (!event.shiftKey) {
+        dispatch(selectToolId(TOOLS.POINTER));
+      }
       return;
     }
     if (selectedToolId === TOOLS.TRASH) {
@@ -219,6 +226,10 @@ export const RuleList = ({
       const insertAt =
         dropIndex === undefined || dropIndex < 0 ? rules.length : Math.min(dropIndex, rules.length);
       onCommentInserted(parentId, insertAt);
+      // One-shot: revert to the pointer unless Shift is held to keep commenting.
+      if (!event.shiftKey) {
+        dispatch(selectToolId(TOOLS.POINTER));
+      }
       return;
     }
     if (selectedToolId === TOOLS.STAMP && stampToolItem && "ruleId" in stampToolItem) {

--- a/frontend/src/editor/components/inspector/rule-list.tsx
+++ b/frontend/src/editor/components/inspector/rule-list.tsx
@@ -1,5 +1,6 @@
 import React, { useContext, useEffect, useRef, useState } from "react";
 
+import { ContentComment, RuleCommentAnnotation } from "./content-comment";
 import { ContentEventGroup } from "./content-event-group";
 import { ContentFlowGroup } from "./content-flow-group";
 import { ContentRule } from "./content-rule";
@@ -32,8 +33,14 @@ export const RuleList = ({
   character: Character;
   collapsed: boolean;
 }) => {
-  const { onRuleMoved, onRuleReRecord, onRuleDeleted, onRuleStamped, onRuleChanged } =
-    useContext(RuleActionsContext);
+  const {
+    onRuleMoved,
+    onRuleReRecord,
+    onRuleDeleted,
+    onRuleStamped,
+    onRuleChanged,
+    onCommentInserted,
+  } = useContext(RuleActionsContext);
   const selectedToolId = useEditorSelector((state) => state.ui.selectedToolId);
   const stampToolItem = useEditorSelector((s) => s.ui.stampToolItem);
   const selectedRuleId = useEditorSelector((s) => s.ui.selectedRuleId);
@@ -103,6 +110,15 @@ export const RuleList = ({
   };
 
   const _onRuleClicked = (event: React.MouseEvent<unknown>, rule: RuleTreeItem) => {
+    if (selectedToolId === TOOLS.COMMENT) {
+      event.stopPropagation();
+      // Clicking a rule attaches an (empty, focused) comment annotation. If it
+      // already has one — or it's itself a free-standing comment — do nothing.
+      if (rule.type !== "comment" && rule.comment === undefined) {
+        onRuleChanged(rule.id, { comment: "" });
+      }
+      return;
+    }
     if (selectedToolId === TOOLS.DISABLE_RULE) {
       // Clicking a rule (or container) flips whether it's enabled. Stay in the
       // tool so several rules can be toggled in a row.
@@ -195,6 +211,16 @@ export const RuleList = ({
   };
 
   const _onListClick = (event: React.MouseEvent<unknown>) => {
+    if (selectedToolId === TOOLS.COMMENT) {
+      // Clicks land here only when they miss a rule (clicks on a rule are
+      // stopped in _onRuleClicked). Drop a free-standing comment at that gap.
+      event.stopPropagation();
+      const dropIndex = _dropIndexForEvent(event);
+      const insertAt =
+        dropIndex === undefined || dropIndex < 0 ? rules.length : Math.min(dropIndex, rules.length);
+      onCommentInserted(parentId, insertAt);
+      return;
+    }
     if (selectedToolId === TOOLS.STAMP && stampToolItem && "ruleId" in stampToolItem) {
       const dropIndex = _dropIndexForEvent(event);
       if (dropIndex === undefined || dropIndex === -1) {
@@ -237,10 +263,15 @@ export const RuleList = ({
         onMouseOver={(event) => _onMouseOver(event, r)}
         onMouseOut={(event) => _onMouseOut(event)}
       >
+        {r.type !== "comment" && r.comment !== undefined && (
+          <RuleCommentAnnotation ruleId={r.id} text={r.comment} />
+        )}
         {r.type === CONTAINER_TYPES.EVENT ? (
           <ContentEventGroup rule={r} character={character} />
         ) : r.type === CONTAINER_TYPES.FLOW ? (
           <ContentFlowGroup rule={r} character={character} />
+        ) : r.type === "comment" ? (
+          <ContentComment comment={r} />
         ) : (
           <ContentRule rule={r} />
         )}

--- a/frontend/src/editor/constants/constants.ts
+++ b/frontend/src/editor/constants/constants.ts
@@ -32,6 +32,8 @@ export enum TOOLS {
 
   // Local to the rules sidebar — clicking a rule toggles its enabled status
   DISABLE_RULE = "disable-rule",
+  // Local to the rules sidebar — annotate a rule or drop a free-standing note
+  COMMENT = "comment",
 
   // Used in the recording flow
   IGNORE_SQUARE = "ignore-square",

--- a/frontend/src/editor/constants/constants.ts
+++ b/frontend/src/editor/constants/constants.ts
@@ -30,6 +30,9 @@ export enum TOOLS {
   PAINT = "paint",
   CREATE_CHARACTER = "create-character",
 
+  // Local to the rules sidebar — clicking a rule toggles its enabled status
+  DISABLE_RULE = "disable-rule",
+
   // Used in the recording flow
   IGNORE_SQUARE = "ignore-square",
   ADD_CLICK_CONDITION = "add-click-condition",

--- a/frontend/src/editor/styles/editor.scss
+++ b/frontend/src/editor/styles/editor.scss
@@ -36,9 +36,11 @@ html {
   -webkit-touch-callout: none; // prevent tap-to-enlarge sprite image
 }
 
-.editor:not(.tool-pointer) .tool-supported {
-  // These cursors are rendered manually so we can center them and draw them large.
-  // The code is in cursor-support.ts
+// Most tools draw their own large image cursor (see cursor-support.ts), so we
+// hide the real cursor over interactive surfaces. The sidebar-local tools
+// (disable-rule / comment) have no image cursor, so they're excluded here and
+// keep a normal cursor (see their blocks below).
+.editor:not(.tool-pointer):not(.tool-disable-rule):not(.tool-comment) .tool-supported {
   cursor: none;
 }
 
@@ -1696,16 +1698,22 @@ html {
   }
 }
 
-// The "disable rule" tool lives in the rules sidebar. The global rule above
-// hides the cursor for non-pointer tools (they draw their own image cursor),
-// but this tool has no image, so restore a normal cursor and show a pointer
-// over the rules you can click to toggle.
-.editor.tool-disable-rule {
-  .tool-supported {
-    cursor: default;
-  }
-  .rules-list .rule-container.tool-supported {
+// The "disable rule" and "comment" tools live in the rules sidebar and act on
+// whatever rule you click. A rule's inner controls (name label, selects,
+// disclosure triangles) normally swallow the click, so we make them transparent
+// to pointer events here — the click then lands on the rule container and the
+// tool's handler runs. The clickable rows get a pointer cursor to match.
+.editor.tool-disable-rule,
+.editor.tool-comment {
+  .rules-list .rule-container {
     cursor: pointer;
+
+    .name,
+    select,
+    .triangle,
+    .scenario {
+      pointer-events: none;
+    }
 
     &.hovering {
       background-color: rgba(255, 255, 255, 0.25);
@@ -1713,20 +1721,14 @@ html {
   }
 }
 
-// The "comment" tool also lives in the rules sidebar (see note above). Restore
-// a normal cursor, show a pointer over rules/gaps you can click, and a text
-// caret over the comment fields themselves.
-.editor.tool-comment {
-  .tool-supported {
-    cursor: default;
-  }
-  .rules-list,
-  .rules-list .rule-container.tool-supported {
-    cursor: pointer;
-  }
-  .comment-text {
-    cursor: text;
-  }
+// The comment tool still needs its comment fields to be directly editable, and
+// the rule-state toggle remains clickable while disabling rules.
+.editor.tool-comment .rules-list .rule-container .comment-text {
+  pointer-events: auto;
+  cursor: text;
+}
+.editor.tool-disable-rule .rules-list .rule-container .rule-toggle-btn {
+  pointer-events: auto;
 }
 
 // ─── Rule sidebar comments ──────────────────────────────────────────────────

--- a/frontend/src/editor/styles/editor.scss
+++ b/frontend/src/editor/styles/editor.scss
@@ -1696,6 +1696,23 @@ html {
   }
 }
 
+// The "disable rule" tool lives in the rules sidebar. The global rule above
+// hides the cursor for non-pointer tools (they draw their own image cursor),
+// but this tool has no image, so restore a normal cursor and show a pointer
+// over the rules you can click to toggle.
+.editor.tool-disable-rule {
+  .tool-supported {
+    cursor: default;
+  }
+  .rules-list .rule-container.tool-supported {
+    cursor: pointer;
+
+    &.hovering {
+      background-color: rgba(255, 255, 255, 0.25);
+    }
+  }
+}
+
 .flex-horizontal {
   display: flex;
 }

--- a/frontend/src/editor/styles/editor.scss
+++ b/frontend/src/editor/styles/editor.scss
@@ -1713,6 +1713,77 @@ html {
   }
 }
 
+// The "comment" tool also lives in the rules sidebar (see note above). Restore
+// a normal cursor, show a pointer over rules/gaps you can click, and a text
+// caret over the comment fields themselves.
+.editor.tool-comment {
+  .tool-supported {
+    cursor: default;
+  }
+  .rules-list,
+  .rules-list .rule-container.tool-supported {
+    cursor: pointer;
+  }
+  .comment-text {
+    cursor: text;
+  }
+}
+
+// ─── Rule sidebar comments ──────────────────────────────────────────────────
+.comment-text {
+  flex: 1;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  resize: none;
+  overflow: hidden;
+  font-family: inherit;
+  font-size: 0.85em;
+  line-height: 1.3em;
+  font-style: italic;
+  color: #5b4636;
+  padding: 1px 3px;
+  outline: none;
+
+  &::placeholder {
+    color: rgba(91, 70, 54, 0.45);
+  }
+}
+
+.rules-list .rule-container.comment {
+  background-color: #fdf6c3;
+  border: 1px solid #e6d97a;
+  border-radius: 4px;
+  margin-bottom: 3px;
+  padding: 3px 4px;
+
+  .comment-body {
+    display: flex;
+    align-items: flex-start;
+    gap: 4px;
+  }
+  .comment-icon {
+    color: #b8a13a;
+    margin-top: 3px;
+  }
+}
+
+.rule-comment-annotation {
+  display: flex;
+  align-items: flex-start;
+  gap: 4px;
+  background-color: rgba(253, 246, 195, 0.9);
+  border-left: 3px solid #e6d97a;
+  border-radius: 3px;
+  margin: 2px 2px 4px;
+  padding: 1px 3px;
+
+  .comment-icon {
+    color: #b8a13a;
+    margin-top: 3px;
+  }
+}
+
 .flex-horizontal {
   display: flex;
 }

--- a/frontend/src/editor/utils/__tests__/scenarios/basic-scenarios.ts
+++ b/frontend/src/editor/utils/__tests__/scenarios/basic-scenarios.ts
@@ -696,3 +696,40 @@ export function stageVariableConditionScenario(): TestScenario {
     },
   };
 }
+
+export function commentIgnoredScenario(): TestScenario {
+  const charId = "char-1";
+  const actorId = "actor-1";
+
+  const ruleActor = makeActor({ id: "rule-actor", characterId: charId });
+  const rule = makeRule({
+    id: "move-right",
+    mainActorId: "rule-actor",
+    actors: { "rule-actor": ruleActor },
+    actions: [{ type: "move", actorId: "rule-actor", delta: { x: 1, y: 0 } }],
+    // An annotation on a rule must not affect evaluation.
+    comment: "moves the actor to the right",
+  });
+  const idleGroup = makeEventGroup({ id: "idle-group", event: "idle", rules: [rule] });
+  // A free-standing comment sitting among the rules must be skipped entirely.
+  const character = makeCharacter({
+    id: charId,
+    name: "Mover",
+    rules: [{ type: "comment", id: "note-1", text: "this character walks" }, idleGroup],
+  });
+  const characters: Characters = { [charId]: character };
+
+  const stageActor = makeActor({ id: actorId, characterId: charId, position: { x: 2, y: 3 } });
+  const stage = makeStage({ id: "stage-1", actors: { [actorId]: stageActor } });
+  const world = makeWorld({ stage });
+
+  return {
+    name: "should ignore free-standing and attached comments during evaluation",
+    characters,
+    world,
+    frames: 1,
+    assertions: (result) => {
+      expectActorPosition(result, actorId, { x: 3, y: 3 });
+    },
+  };
+}

--- a/frontend/src/editor/utils/world-operator.test.ts
+++ b/frontend/src/editor/utils/world-operator.test.ts
@@ -18,6 +18,7 @@ import {
   globalModifyScenario,
   stageVariableModifyScenario,
   stageVariableConditionScenario,
+  commentIgnoredScenario,
 } from "./__tests__/scenarios/basic-scenarios";
 import { collisionScenario, coinCollectionScenario } from "./__tests__/scenarios/multi-actor-scenarios";
 import { chaseGameScenario } from "./__tests__/scenarios/chase-game-scenario";
@@ -125,6 +126,12 @@ describe("world-operator integration", () => {
   describe("transforms", () => {
     it("should set actor transform (rotation)", () => {
       runScenario(transformRotationScenario());
+    });
+  });
+
+  describe("comments", () => {
+    it("should ignore free-standing and attached comments during evaluation", () => {
+      runScenario(commentIgnoredScenario());
     });
   });
 

--- a/frontend/src/editor/utils/world-operator.ts
+++ b/frontend/src/editor/utils/world-operator.ts
@@ -235,6 +235,11 @@ export default function WorldOperator(previousWorld: WorldMinimal, characters: C
         matchedActors: {},
       };
 
+      // Comments are annotations only — never evaluated.
+      if (rule.type === "comment") {
+        return emptyDetails;
+      }
+
       // Skip disabled rules
       if (rule.enabled === false) {
         return emptyDetails;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -113,7 +113,7 @@ export type RuleTreeEventItem = {
   code?: number | string; // used for key event (legacy numeric keyCode or codako key name)
   id: string;
   enabled?: boolean;
-  comment?: string; // optional author note attached to this item
+  comment?: string;
 };
 
 export type RuleTreeFlowItemCheck = {
@@ -130,7 +130,7 @@ export type RuleTreeFlowItemBase = {
   rules: RuleTreeItem[];
   id: string;
   enabled?: boolean;
-  comment?: string; // optional author note attached to this item
+  comment?: string;
 
   check?: RuleTreeFlowItemCheck;
 };
@@ -206,7 +206,7 @@ export type Rule = {
   id: string;
   name: string;
   enabled?: boolean;
-  comment?: string; // optional author note attached to this rule
+  comment?: string;
 };
 
 export type Actor = {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -113,6 +113,7 @@ export type RuleTreeEventItem = {
   code?: number | string; // used for key event (legacy numeric keyCode or codako key name)
   id: string;
   enabled?: boolean;
+  comment?: string; // optional author note attached to this item
 };
 
 export type RuleTreeFlowItemCheck = {
@@ -129,6 +130,7 @@ export type RuleTreeFlowItemBase = {
   rules: RuleTreeItem[];
   id: string;
   enabled?: boolean;
+  comment?: string; // optional author note attached to this item
 
   check?: RuleTreeFlowItemCheck;
 };
@@ -156,7 +158,18 @@ export type RuleTreeFlowItem =
   | RuleTreeFlowItemAll
   | RuleTreeFlowLoopItem;
 
-export type RuleTreeItem = RuleTreeEventItem | RuleTreeFlowItem | Rule;
+/**
+ * A free-standing comment that lives in a character's rule tree (between rules
+ * or inside a container) purely as an annotation. It is never evaluated by the
+ * simulation engine.
+ */
+export type RuleTreeComment = {
+  type: "comment";
+  id: string;
+  text: string;
+};
+
+export type RuleTreeItem = RuleTreeEventItem | RuleTreeFlowItem | Rule | RuleTreeComment;
 
 export type RuleCondition = {
   key: string;
@@ -193,6 +206,7 @@ export type Rule = {
   id: string;
   name: string;
   enabled?: boolean;
+  comment?: string; // optional author note attached to this rule
 };
 
 export type Actor = {


### PR DESCRIPTION
## Summary
This PR adds two new sidebar-local tools for managing rules: a **comment tool** for annotating rules and adding free-standing notes, and a **disable-rule tool** for quickly toggling rule enabled/disabled status without opening the rule editor.

## Key Changes

- **New comment system**: 
  - Added `RuleTreeComment` type for free-standing comments that live in the rule tree
  - Added optional `comment` field to rules and containers for inline annotations
  - Comments are purely annotations and are skipped during simulation evaluation

- **Comment UI components**:
  - `CommentTextEditor`: Auto-growing textarea for editing comments with blur-to-commit behavior
  - `ContentComment`: Renders free-standing comments in the rule list
  - `RuleCommentAnnotation`: Renders inline comment annotations on rules
  - `CommentToolButton`: Sidebar button to activate comment mode

- **Disable-rule tool**:
  - `DisableRuleToolButton`: Sidebar button to activate disable-rule mode
  - Clicking rules while active toggles their `enabled` status
  - Allows quick muting/unmuting of rules without opening the editor

- **Styling**:
  - Added cursor and hover styles for both new tools
  - Yellow background and styling for comment containers
  - Proper text cursor in comment fields, pointer cursor over clickable rules

- **Integration**:
  - Added `COMMENT` and `DISABLE_RULE` tool constants
  - Extended `RuleActionsContext` with `onCommentInserted` and `onCommentRemoved` handlers
  - Updated `RuleList` to handle clicks for both new tools
  - Added test scenario verifying comments are ignored during evaluation

## Implementation Details

- Comments use the same auto-focus and blur-to-commit pattern as other rule editors
- Empty comments are automatically removed on blur
- Event propagation is stopped on comment fields to prevent rule-list tool handlers from firing
- Both tools are disabled during recording to avoid confusion
- Free-standing comments can be inserted at any position in the rule tree; annotations attach to existing rules

https://claude.ai/code/session_018quWqQHcTJ1jy3PwWd7yD4