### PR TITLE
Prevent thumbnail updates during draft saves

### DIFF
--- a/api/src/routes/worlds.ts
+++ b/api/src/routes/worlds.ts
@@ -162,9 +162,13 @@ router.put("/worlds/:objectId", userFromBasicAuth, async (req, res) => {
     world.unsavedData = null;
     world.unsavedDataUpdatedAt = null;
   } else {
-    // Default: saveDraft - save to unsavedData and update timestamp
+    // Default: saveDraft - save to unsavedData and update timestamp.
+    // Note: we deliberately do NOT update world.thumbnail here. The thumbnail
+    // represents the last committed (saved) state of the world, so it should
+    // only change on an explicit "save". Updating it during draft autosaves
+    // would make the world card reflect unsaved changes even after the user
+    // exits without saving or reverts to the saved version.
     world.name = req.body.name || world.name;
-    world.thumbnail = req.body.thumbnail || world.thumbnail;
     if (req.body.data) {
       world.unsavedData = req.body.data;
       world.unsavedDataUpdatedAt = new Date();

--- a/api/src/test/worlds.test.ts
+++ b/api/src/test/worlds.test.ts
@@ -209,6 +209,38 @@ describe("Worlds API", () => {
       expect(res.body.data).to.deep.equal({ updated: true });
     });
 
+    it("should not change the thumbnail on a draft save", async () => {
+      const { user, authHeader } = await createTestUser("testuser", "password123");
+
+      const worldRepo = AppDataSource.getRepository(World);
+      const world = await worldRepo.save({
+        name: "Original Name",
+        thumbnail: "saved-thumbnail",
+        userId: user.id,
+      });
+
+      // A draft save (default action) carries the in-progress thumbnail, but it
+      // must not overwrite the committed thumbnail shown on the world card.
+      await request(app)
+        .put(`/worlds/${world.id}?action=saveDraft`)
+        .set("Authorization", authHeader)
+        .send({ thumbnail: "draft-thumbnail", data: { draft: true } })
+        .expect(200);
+
+      const afterDraft = await worldRepo.findOneByOrFail({ id: world.id });
+      expect(afterDraft.thumbnail).to.equal("saved-thumbnail");
+
+      // An explicit save should update the thumbnail.
+      await request(app)
+        .put(`/worlds/${world.id}?action=save`)
+        .set("Authorization", authHeader)
+        .send({ thumbnail: "committed-thumbnail", data: { saved: true } })
+        .expect(200);
+
+      const afterSave = await worldRepo.findOneByOrFail({ id: world.id });
+      expect(afterSave.thumbnail).to.equal("committed-thumbnail");
+    });
+
     it("should return 404 for world owned by different user", async () => {
       const { user: owner } = await createTestUser("owner", "password123");
       const { authHeader: attackerAuth } = await createTestUser("attacker", "password123");

--- a/frontend/src/components/editor-page.tsx
+++ b/frontend/src/components/editor-page.tsx
@@ -113,10 +113,12 @@ const LocalStorageAdapter = {
       delete _value.unsavedData;
       delete _value.unsavedDataUpdatedAt;
     } else {
-      // Default: saveDraft - save to unsavedData and update timestamp
+      // Default: saveDraft - save to unsavedData and update timestamp.
+      // Deliberately do NOT update _value.thumbnail here: the thumbnail
+      // reflects the last committed (saved) state, so it should only change on
+      // an explicit "save", not on draft autosaves.
       _value.unsavedData = json.data;
       if (json.name) _value.name = json.name;
-      if (json.thumbnail) _value.thumbnail = json.thumbnail;
       _value.unsavedDataUpdatedAt = new Date().toISOString();
     }
     try {


### PR DESCRIPTION
## Summary
This change ensures that the world thumbnail only updates on explicit saves, not during draft autosaves. This prevents the world card from displaying unsaved changes and maintains a clear distinction between the committed state (shown on the card) and the in-progress draft state.

## Changes
- **Backend (api/src/routes/worlds.ts)**: Removed thumbnail update logic from the draft save path (`saveDraft` action). The thumbnail now only updates when `action=save` is explicitly specified.
- **Frontend (frontend/src/components/editor-page.tsx)**: Removed thumbnail update from the local storage draft save logic to match backend behavior.
- **Tests (api/src/test/worlds.test.ts)**: Added comprehensive test case verifying that:
  - Draft saves with a new thumbnail do not update the persisted thumbnail
  - Explicit saves with a new thumbnail do update the persisted thumbnail

## Implementation Details
The thumbnail field represents the last committed state of the world and is displayed on the world card. By preventing updates during draft autosaves, users can safely work on changes without the card reflecting unsaved state. This is particularly important for the autosave flow where draft data is continuously saved without user confirmation.

https://claude.ai/code/session_011vQj1oxFrDM3atjdT1cDva